### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,8 @@
 name: Lint
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/GarrettBeatty/doublecube.gg/security/code-scanning/8](https://github.com/GarrettBeatty/doublecube.gg/security/code-scanning/8)

In general, the fix is to explicitly declare the `permissions` for the `GITHUB_TOKEN` in the workflow, limiting them to the least privilege needed. For this linting job, only read access to repository contents is required so `contents: read` is sufficient.

The best way to fix this without changing existing functionality is to add a `permissions` block at the workflow level (top-level, alongside `name` and `on`). This will apply to all jobs in the workflow, including `eslint`, and ensures the token only has read access to repository contents. Concretely, in `.github/workflows/lint.yml`, insert:

```yaml
permissions:
  contents: read
```

after the `name: Lint` line and before the `on:` block. No other changes, imports, or steps are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
