### PR TITLE
Add daily puzzle feature

### DIFF
--- a/Backgammon.Server/Configuration/PuzzleSettings.cs
+++ b/Backgammon.Server/Configuration/PuzzleSettings.cs
@@ -1,0 +1,37 @@
+namespace Backgammon.Server.Configuration;
+
+/// <summary>
+/// Configuration settings for daily puzzle generation
+/// </summary>
+public class PuzzleSettings
+{
+    public const string SectionName = "Puzzle";
+
+    /// <summary>
+    /// Evaluator type to use for puzzle solution analysis: "Heuristic" or "Gnubg"
+    /// </summary>
+    public string EvaluatorType { get; set; } = "Gnubg";
+
+    /// <summary>
+    /// Number of gnubg evaluation plies (0-3). Higher = more accurate but slower.
+    /// Only used when EvaluatorType is "Gnubg".
+    /// </summary>
+    public int GnubgPlies { get; set; } = 2;
+
+    /// <summary>
+    /// Equity tolerance for accepting alternative moves as correct.
+    /// Moves within this equity difference from optimal are accepted.
+    /// </summary>
+    public double EquityTolerance { get; set; } = 0.02;
+
+    /// <summary>
+    /// Time of day (UTC) when the daily puzzle is generated.
+    /// </summary>
+    public TimeSpan GenerationTimeUtc { get; set; } = TimeSpan.Zero;
+
+    /// <summary>
+    /// Whether to generate puzzles automatically at the scheduled time.
+    /// Set to false to disable automatic generation (useful for testing).
+    /// </summary>
+    public bool EnableAutomaticGeneration { get; set; } = true;
+}

--- a/Backgammon.Server/Models/AlternativeMove.cs
+++ b/Backgammon.Server/Models/AlternativeMove.cs
@@ -1,0 +1,33 @@
+using System.Text.Json.Serialization;
+
+namespace Backgammon.Server.Models;
+
+/// <summary>
+/// Alternative move that is also accepted as correct.
+/// </summary>
+public class AlternativeMove
+{
+    /// <summary>
+    /// Gets or sets the move sequence.
+    /// </summary>
+    [JsonPropertyName("moves")]
+    public List<MoveDto> Moves { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the move notation (e.g., "24/18 13/11").
+    /// </summary>
+    [JsonPropertyName("notation")]
+    public string Notation { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the equity of this move sequence.
+    /// </summary>
+    [JsonPropertyName("equity")]
+    public double Equity { get; set; }
+
+    /// <summary>
+    /// Gets or sets the equity difference from the best move (always >= 0).
+    /// </summary>
+    [JsonPropertyName("equityLoss")]
+    public double EquityLoss { get; set; }
+}

--- a/Backgammon.Server/Models/DailyPuzzle.cs
+++ b/Backgammon.Server/Models/DailyPuzzle.cs
@@ -1,0 +1,118 @@
+using System.Text.Json.Serialization;
+
+namespace Backgammon.Server.Models;
+
+/// <summary>
+/// Entity model for a daily puzzle stored in DynamoDB.
+/// Contains the position, dice roll, and optimal solution.
+/// </summary>
+public class DailyPuzzle
+{
+    /// <summary>
+    /// Unique puzzle identifier
+    /// </summary>
+    [JsonPropertyName("puzzleId")]
+    public string PuzzleId { get; set; } = Guid.NewGuid().ToString();
+
+    /// <summary>
+    /// Date of the puzzle in yyyy-MM-dd format (e.g., "2026-01-10")
+    /// </summary>
+    [JsonPropertyName("puzzleDate")]
+    public string PuzzleDate { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Position encoded in SGF format for reconstruction
+    /// </summary>
+    [JsonPropertyName("positionSgf")]
+    public string PositionSgf { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Current player to move: "White" or "Red"
+    /// </summary>
+    [JsonPropertyName("currentPlayer")]
+    public string CurrentPlayer { get; set; } = "White";
+
+    /// <summary>
+    /// The dice roll for this puzzle [die1, die2]
+    /// </summary>
+    [JsonPropertyName("dice")]
+    public int[] Dice { get; set; } = new int[2];
+
+    /// <summary>
+    /// Board state for display (24 points)
+    /// </summary>
+    [JsonPropertyName("boardState")]
+    public List<PointStateDto> BoardState { get; set; } = new();
+
+    /// <summary>
+    /// Number of white checkers on the bar
+    /// </summary>
+    [JsonPropertyName("whiteCheckersOnBar")]
+    public int WhiteCheckersOnBar { get; set; }
+
+    /// <summary>
+    /// Number of red checkers on the bar
+    /// </summary>
+    [JsonPropertyName("redCheckersOnBar")]
+    public int RedCheckersOnBar { get; set; }
+
+    /// <summary>
+    /// Number of white checkers borne off
+    /// </summary>
+    [JsonPropertyName("whiteBornOff")]
+    public int WhiteBornOff { get; set; }
+
+    /// <summary>
+    /// Number of red checkers borne off
+    /// </summary>
+    [JsonPropertyName("redBornOff")]
+    public int RedBornOff { get; set; }
+
+    /// <summary>
+    /// The optimal move sequence as determined by the evaluator
+    /// </summary>
+    [JsonPropertyName("bestMoves")]
+    public List<MoveDto> BestMoves { get; set; } = new();
+
+    /// <summary>
+    /// Best moves in standard notation (e.g., "24/20 13/11")
+    /// </summary>
+    [JsonPropertyName("bestMovesNotation")]
+    public string BestMovesNotation { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Equity of the best move sequence
+    /// </summary>
+    [JsonPropertyName("bestMoveEquity")]
+    public double BestMoveEquity { get; set; }
+
+    /// <summary>
+    /// Alternative move sequences within the equity tolerance that are also accepted
+    /// </summary>
+    [JsonPropertyName("alternativeMoves")]
+    public List<AlternativeMove> AlternativeMoves { get; set; } = new();
+
+    /// <summary>
+    /// Evaluator used to analyze this puzzle ("Gnubg" or "Heuristic")
+    /// </summary>
+    [JsonPropertyName("evaluatorType")]
+    public string EvaluatorType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// When the puzzle was created
+    /// </summary>
+    [JsonPropertyName("createdAt")]
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// Number of users who have solved this puzzle
+    /// </summary>
+    [JsonPropertyName("solvedCount")]
+    public int SolvedCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the total number of attempts on this puzzle.
+    /// </summary>
+    [JsonPropertyName("attemptCount")]
+    public int AttemptCount { get; set; }
+}

--- a/Backgammon.Server/Models/DailyPuzzleDto.cs
+++ b/Backgammon.Server/Models/DailyPuzzleDto.cs
@@ -1,0 +1,88 @@
+using System.Text.Json.Serialization;
+
+namespace Backgammon.Server.Models;
+
+/// <summary>
+/// Data transfer object for sending daily puzzle data to the client.
+/// Note: Best moves are NOT included until the user solves the puzzle.
+/// </summary>
+public class DailyPuzzleDto
+{
+    /// <summary>
+    /// Unique puzzle identifier
+    /// </summary>
+    [JsonPropertyName("puzzleId")]
+    public string PuzzleId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Date of the puzzle in yyyy-MM-dd format
+    /// </summary>
+    [JsonPropertyName("puzzleDate")]
+    public string PuzzleDate { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Current player to move: "White" or "Red"
+    /// </summary>
+    [JsonPropertyName("currentPlayer")]
+    public string CurrentPlayer { get; set; } = "White";
+
+    /// <summary>
+    /// The dice roll for this puzzle [die1, die2]
+    /// </summary>
+    [JsonPropertyName("dice")]
+    public int[] Dice { get; set; } = new int[2];
+
+    /// <summary>
+    /// Board state for display (24 points)
+    /// </summary>
+    [JsonPropertyName("boardState")]
+    public List<PointStateDto> BoardState { get; set; } = new();
+
+    /// <summary>
+    /// Number of white checkers on the bar
+    /// </summary>
+    [JsonPropertyName("whiteCheckersOnBar")]
+    public int WhiteCheckersOnBar { get; set; }
+
+    /// <summary>
+    /// Number of red checkers on the bar
+    /// </summary>
+    [JsonPropertyName("redCheckersOnBar")]
+    public int RedCheckersOnBar { get; set; }
+
+    /// <summary>
+    /// Number of white checkers borne off
+    /// </summary>
+    [JsonPropertyName("whiteBornOff")]
+    public int WhiteBornOff { get; set; }
+
+    /// <summary>
+    /// Number of red checkers borne off
+    /// </summary>
+    [JsonPropertyName("redBornOff")]
+    public int RedBornOff { get; set; }
+
+    /// <summary>
+    /// Whether the current user has already solved this puzzle
+    /// </summary>
+    [JsonPropertyName("alreadySolved")]
+    public bool AlreadySolved { get; set; }
+
+    /// <summary>
+    /// Number of attempts the user has made today
+    /// </summary>
+    [JsonPropertyName("attemptsToday")]
+    public int AttemptsToday { get; set; }
+
+    /// <summary>
+    /// Best moves - only populated after user has solved the puzzle
+    /// </summary>
+    [JsonPropertyName("bestMoves")]
+    public List<MoveDto>? BestMoves { get; set; }
+
+    /// <summary>
+    /// Best moves notation - only populated after user has solved the puzzle
+    /// </summary>
+    [JsonPropertyName("bestMovesNotation")]
+    public string? BestMovesNotation { get; set; }
+}

--- a/Backgammon.Server/Models/PuzzleAttempt.cs
+++ b/Backgammon.Server/Models/PuzzleAttempt.cs
@@ -1,0 +1,70 @@
+using System.Text.Json.Serialization;
+
+namespace Backgammon.Server.Models;
+
+/// <summary>
+/// Entity model for a user's attempt at a daily puzzle.
+/// Stored in DynamoDB with PK=USER#{userId}, SK=PUZZLE_ATTEMPT#{date}
+/// </summary>
+public class PuzzleAttempt
+{
+    /// <summary>
+    /// User ID who made the attempt
+    /// </summary>
+    [JsonPropertyName("userId")]
+    public string UserId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Puzzle ID attempted
+    /// </summary>
+    [JsonPropertyName("puzzleId")]
+    public string PuzzleId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Date of the puzzle in yyyy-MM-dd format
+    /// </summary>
+    [JsonPropertyName("puzzleDate")]
+    public string PuzzleDate { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The moves the user submitted
+    /// </summary>
+    [JsonPropertyName("submittedMoves")]
+    public List<MoveDto> SubmittedMoves { get; set; } = new();
+
+    /// <summary>
+    /// Submitted moves in notation format
+    /// </summary>
+    [JsonPropertyName("submittedNotation")]
+    public string SubmittedNotation { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Whether the user's solution was correct (within tolerance)
+    /// </summary>
+    [JsonPropertyName("isCorrect")]
+    public bool IsCorrect { get; set; }
+
+    /// <summary>
+    /// Equity loss compared to the optimal move (0 = perfect)
+    /// </summary>
+    [JsonPropertyName("equityLoss")]
+    public double EquityLoss { get; set; }
+
+    /// <summary>
+    /// Number of attempts the user made before getting it right (or giving up)
+    /// </summary>
+    [JsonPropertyName("attemptCount")]
+    public int AttemptCount { get; set; }
+
+    /// <summary>
+    /// When the user first attempted this puzzle
+    /// </summary>
+    [JsonPropertyName("createdAt")]
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// When the user solved this puzzle (null if never solved)
+    /// </summary>
+    [JsonPropertyName("solvedAt")]
+    public DateTime? SolvedAt { get; set; }
+}

--- a/Backgammon.Server/Models/PuzzleResultDto.cs
+++ b/Backgammon.Server/Models/PuzzleResultDto.cs
@@ -1,0 +1,57 @@
+using System.Text.Json.Serialization;
+
+namespace Backgammon.Server.Models;
+
+/// <summary>
+/// Data transfer object for puzzle submission result.
+/// </summary>
+public class PuzzleResultDto
+{
+    /// <summary>
+    /// Whether the submitted solution was correct
+    /// </summary>
+    [JsonPropertyName("isCorrect")]
+    public bool IsCorrect { get; set; }
+
+    /// <summary>
+    /// Equity loss compared to optimal (0 = perfect, higher = worse)
+    /// </summary>
+    [JsonPropertyName("equityLoss")]
+    public double EquityLoss { get; set; }
+
+    /// <summary>
+    /// Human-readable feedback message
+    /// </summary>
+    [JsonPropertyName("feedback")]
+    public string Feedback { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The optimal moves - only revealed when correct or after giving up
+    /// </summary>
+    [JsonPropertyName("bestMoves")]
+    public List<MoveDto>? BestMoves { get; set; }
+
+    /// <summary>
+    /// Best moves in notation format
+    /// </summary>
+    [JsonPropertyName("bestMovesNotation")]
+    public string? BestMovesNotation { get; set; }
+
+    /// <summary>
+    /// User's current streak after this attempt
+    /// </summary>
+    [JsonPropertyName("currentStreak")]
+    public int CurrentStreak { get; set; }
+
+    /// <summary>
+    /// Whether the streak was broken (missed a day)
+    /// </summary>
+    [JsonPropertyName("streakBroken")]
+    public bool StreakBroken { get; set; }
+
+    /// <summary>
+    /// Total number of attempts on this puzzle
+    /// </summary>
+    [JsonPropertyName("attemptCount")]
+    public int AttemptCount { get; set; }
+}

--- a/Backgammon.Server/Models/PuzzleStreakInfo.cs
+++ b/Backgammon.Server/Models/PuzzleStreakInfo.cs
@@ -1,0 +1,46 @@
+using System.Text.Json.Serialization;
+
+namespace Backgammon.Server.Models;
+
+/// <summary>
+/// Entity model for a user's puzzle streak information.
+/// Stored in DynamoDB with PK=USER#{userId}, SK=PUZZLE_STREAK
+/// </summary>
+public class PuzzleStreakInfo
+{
+    /// <summary>
+    /// User ID
+    /// </summary>
+    [JsonPropertyName("userId")]
+    public string UserId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Current consecutive days streak
+    /// </summary>
+    [JsonPropertyName("currentStreak")]
+    public int CurrentStreak { get; set; }
+
+    /// <summary>
+    /// Best streak ever achieved
+    /// </summary>
+    [JsonPropertyName("bestStreak")]
+    public int BestStreak { get; set; }
+
+    /// <summary>
+    /// Date of the last puzzle solved (yyyy-MM-dd format)
+    /// </summary>
+    [JsonPropertyName("lastSolvedDate")]
+    public string? LastSolvedDate { get; set; }
+
+    /// <summary>
+    /// Total number of puzzles solved
+    /// </summary>
+    [JsonPropertyName("totalSolved")]
+    public int TotalSolved { get; set; }
+
+    /// <summary>
+    /// Total number of puzzle attempts (including incorrect)
+    /// </summary>
+    [JsonPropertyName("totalAttempts")]
+    public int TotalAttempts { get; set; }
+}

--- a/Backgammon.Server/Program.cs
+++ b/Backgammon.Server/Program.cs
@@ -187,6 +187,22 @@ builder.Services.AddSingleton<PositionEvaluatorFactory>();
 builder.Services.AddSingleton<AnalysisService>();
 // ========== END ANALYSIS CONFIGURATION ==========
 
+// ========== DAILY PUZZLE CONFIGURATION ==========
+// Configure puzzle settings
+builder.Services.Configure<Backgammon.Server.Configuration.PuzzleSettings>(
+    builder.Configuration.GetSection(Backgammon.Server.Configuration.PuzzleSettings.SectionName));
+
+// Register puzzle repository
+builder.Services.AddSingleton<IPuzzleRepository, Backgammon.Server.Services.DynamoDb.DynamoDbPuzzleRepository>();
+
+// Register puzzle services
+builder.Services.AddSingleton<RandomPositionGenerator>();
+builder.Services.AddSingleton<IDailyPuzzleService, DailyPuzzleService>();
+
+// Register puzzle generation background service
+builder.Services.AddHostedService<DailyPuzzleGenerationService>();
+// ========== END DAILY PUZZLE CONFIGURATION ==========
+
 // ELO rating service
 builder.Services.AddSingleton<IEloRatingService, EloRatingService>();
 

--- a/Backgammon.Server/Services/DailyPuzzleGenerationService.cs
+++ b/Backgammon.Server/Services/DailyPuzzleGenerationService.cs
@@ -1,0 +1,149 @@
+using Backgammon.Server.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Backgammon.Server.Services;
+
+/// <summary>
+/// Background service that generates daily puzzles at the configured time (default: midnight UTC).
+/// Also ensures today's puzzle exists on startup.
+/// </summary>
+public class DailyPuzzleGenerationService : BackgroundService
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly PuzzleSettings _settings;
+    private readonly ILogger<DailyPuzzleGenerationService> _logger;
+
+    public DailyPuzzleGenerationService(
+        IServiceProvider serviceProvider,
+        IOptions<PuzzleSettings> settings,
+        ILogger<DailyPuzzleGenerationService> logger)
+    {
+        _serviceProvider = serviceProvider;
+        _settings = settings.Value;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!_settings.EnableAutomaticGeneration)
+        {
+            _logger.LogInformation("Automatic puzzle generation is disabled");
+            return;
+        }
+
+        _logger.LogInformation(
+            "Daily puzzle generation service started. Generation time: {Time} UTC",
+            _settings.GenerationTimeUtc);
+
+        // Ensure today's puzzle exists on startup
+        await EnsureTodaysPuzzleExistsAsync(stoppingToken);
+
+        // Main loop - generate puzzles at the scheduled time
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                var delay = CalculateDelayUntilNextGeneration();
+                _logger.LogDebug("Next puzzle generation in {Delay}", delay);
+
+                await Task.Delay(delay, stoppingToken);
+
+                if (!stoppingToken.IsCancellationRequested)
+                {
+                    await GenerateDailyPuzzleAsync(stoppingToken);
+                }
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                // Normal shutdown
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error in puzzle generation loop. Retrying in 1 hour.");
+                await Task.Delay(TimeSpan.FromHours(1), stoppingToken);
+            }
+        }
+
+        _logger.LogInformation("Daily puzzle generation service stopped");
+    }
+
+    private async Task EnsureTodaysPuzzleExistsAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var scope = _serviceProvider.CreateScope();
+            var puzzleService = scope.ServiceProvider.GetRequiredService<IDailyPuzzleService>();
+
+            var today = DateTime.UtcNow.ToString("yyyy-MM-dd");
+
+            if (await puzzleService.PuzzleExistsAsync(today))
+            {
+                _logger.LogInformation("Today's puzzle ({Date}) already exists", today);
+                return;
+            }
+
+            _logger.LogInformation("Generating today's puzzle for {Date}", today);
+            await puzzleService.GeneratePuzzleForDateAsync(today);
+            _logger.LogInformation("Successfully generated puzzle for {Date}", today);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to ensure today's puzzle exists");
+            // Don't throw - we'll try again at the scheduled time
+        }
+    }
+
+    private async Task GenerateDailyPuzzleAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var scope = _serviceProvider.CreateScope();
+            var puzzleService = scope.ServiceProvider.GetRequiredService<IDailyPuzzleService>();
+
+            // Generate for today (which is now after midnight)
+            var today = DateTime.UtcNow.ToString("yyyy-MM-dd");
+
+            if (await puzzleService.PuzzleExistsAsync(today))
+            {
+                _logger.LogInformation("Puzzle for {Date} already exists, skipping generation", today);
+                return;
+            }
+
+            _logger.LogInformation("Generating puzzle for {Date}", today);
+            await puzzleService.GeneratePuzzleForDateAsync(today);
+            _logger.LogInformation("Successfully generated puzzle for {Date}", today);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to generate daily puzzle");
+            throw;
+        }
+    }
+
+    private TimeSpan CalculateDelayUntilNextGeneration()
+    {
+        var now = DateTime.UtcNow;
+        var today = now.Date;
+        var generationTime = today.Add(_settings.GenerationTimeUtc);
+
+        // If we've already passed today's generation time, schedule for tomorrow
+        if (now >= generationTime)
+        {
+            generationTime = generationTime.AddDays(1);
+        }
+
+        var delay = generationTime - now;
+
+        // Ensure minimum delay of 1 second to avoid tight loops
+        if (delay < TimeSpan.FromSeconds(1))
+        {
+            delay = TimeSpan.FromSeconds(1);
+        }
+
+        return delay;
+    }
+}

--- a/Backgammon.Server/Services/DailyPuzzleService.cs
+++ b/Backgammon.Server/Services/DailyPuzzleService.cs
@@ -1,0 +1,404 @@
+using Backgammon.Analysis;
+using Backgammon.Analysis.Models;
+using Backgammon.Core;
+using Backgammon.Server.Configuration;
+using Backgammon.Server.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Backgammon.Server.Services;
+
+/// <summary>
+/// Service for daily puzzle operations including generation, retrieval, and answer validation.
+/// </summary>
+public class DailyPuzzleService : IDailyPuzzleService
+{
+    private readonly IPuzzleRepository _puzzleRepository;
+    private readonly RandomPositionGenerator _positionGenerator;
+    private readonly PositionEvaluatorFactory _evaluatorFactory;
+    private readonly PuzzleSettings _settings;
+    private readonly ILogger<DailyPuzzleService> _logger;
+
+    public DailyPuzzleService(
+        IPuzzleRepository puzzleRepository,
+        RandomPositionGenerator positionGenerator,
+        PositionEvaluatorFactory evaluatorFactory,
+        IOptions<PuzzleSettings> settings,
+        ILogger<DailyPuzzleService> logger)
+    {
+        _puzzleRepository = puzzleRepository;
+        _positionGenerator = positionGenerator;
+        _evaluatorFactory = evaluatorFactory;
+        _settings = settings.Value;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task<DailyPuzzleDto?> GetTodaysPuzzleAsync(string? userId)
+    {
+        var today = DateTime.UtcNow.ToString("yyyy-MM-dd");
+        return await GetPuzzleByDateAsync(today, userId);
+    }
+
+    /// <inheritdoc/>
+    public async Task<DailyPuzzleDto?> GetPuzzleByDateAsync(string date, string? userId)
+    {
+        var puzzle = await _puzzleRepository.GetPuzzleByDateAsync(date);
+        if (puzzle == null)
+        {
+            _logger.LogWarning("No puzzle found for date {Date}", date);
+            return null;
+        }
+
+        // Check if user has already solved this puzzle
+        PuzzleAttempt? attempt = null;
+        if (!string.IsNullOrEmpty(userId))
+        {
+            attempt = await _puzzleRepository.GetAttemptAsync(userId, date);
+        }
+
+        return MapToDto(puzzle, attempt);
+    }
+
+    /// <inheritdoc/>
+    public async Task<PuzzleResultDto> SubmitAnswerAsync(string userId, string puzzleDate, List<MoveDto> moves)
+    {
+        var puzzle = await _puzzleRepository.GetPuzzleByDateAsync(puzzleDate);
+        if (puzzle == null)
+        {
+            throw new InvalidOperationException($"Puzzle not found for date {puzzleDate}");
+        }
+
+        // Get or create attempt record
+        var attempt = await _puzzleRepository.GetAttemptAsync(userId, puzzleDate)
+            ?? new PuzzleAttempt
+            {
+                UserId = userId,
+                PuzzleId = puzzle.PuzzleId,
+                PuzzleDate = puzzleDate,
+                CreatedAt = DateTime.UtcNow
+            };
+
+        attempt.AttemptCount++;
+        attempt.SubmittedMoves = moves;
+        attempt.SubmittedNotation = FormatMovesNotation(moves);
+
+        // Check if the submitted moves match the best moves or an alternative
+        var (isCorrect, equityLoss) = EvaluateAnswer(puzzle, moves);
+        attempt.IsCorrect = isCorrect;
+        attempt.EquityLoss = equityLoss;
+
+        // Track if this is the first time the user solved this puzzle
+        var isFirstSolve = isCorrect && !attempt.SolvedAt.HasValue;
+
+        if (isFirstSolve)
+        {
+            attempt.SolvedAt = DateTime.UtcNow;
+        }
+
+        // Update attempt and puzzle stats
+        await _puzzleRepository.SaveAttemptAsync(attempt);
+        await _puzzleRepository.IncrementAttemptCountAsync(puzzleDate);
+
+        if (isFirstSolve)
+        {
+            // Increment solved count when user solves for the first time (regardless of attempt count)
+            await _puzzleRepository.IncrementSolvedCountAsync(puzzleDate);
+        }
+
+        // Update streak
+        var streakInfo = await UpdateStreakAsync(userId, puzzleDate, isCorrect);
+
+        return new PuzzleResultDto
+        {
+            IsCorrect = isCorrect,
+            EquityLoss = equityLoss,
+            Feedback = GetFeedback(isCorrect, equityLoss, attempt.AttemptCount),
+            BestMoves = isCorrect ? puzzle.BestMoves : null,
+            BestMovesNotation = isCorrect ? puzzle.BestMovesNotation : null,
+            CurrentStreak = streakInfo.CurrentStreak,
+            StreakBroken = false, // Streak only breaks if you miss a day, not wrong answer
+            AttemptCount = attempt.AttemptCount
+        };
+    }
+
+    /// <inheritdoc/>
+    public async Task<PuzzleStreakInfo> GetStreakInfoAsync(string userId)
+    {
+        var streakInfo = await _puzzleRepository.GetStreakInfoAsync(userId);
+        return streakInfo ?? new PuzzleStreakInfo { UserId = userId };
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> PuzzleExistsAsync(string date)
+    {
+        return await _puzzleRepository.PuzzleExistsAsync(date);
+    }
+
+    /// <inheritdoc/>
+    public async Task<DailyPuzzle> GeneratePuzzleForDateAsync(string date)
+    {
+        _logger.LogInformation(
+            "Generating puzzle for date {Date} using {EvaluatorType} evaluator",
+            date,
+            _settings.EvaluatorType);
+
+        // Generate a random position
+        var engine = _positionGenerator.GenerateRandomPosition();
+
+        // Get best moves using the configured evaluator
+        var evaluator = _evaluatorFactory.GetEvaluator(_settings.EvaluatorType);
+        var analysis = evaluator.FindBestMoves(engine);
+
+        if (analysis.TopMoves.Count == 0)
+        {
+            throw new InvalidOperationException("Failed to find best moves for generated position");
+        }
+
+        var bestMove = analysis.TopMoves[0];
+
+        // Create puzzle entity
+        var puzzle = new DailyPuzzle
+        {
+            PuzzleId = Guid.NewGuid().ToString(),
+            PuzzleDate = date,
+            PositionSgf = SgfSerializer.ExportPosition(engine),
+            CurrentPlayer = engine.CurrentPlayer.Color.ToString(),
+            Dice = new[] { engine.Dice.Die1, engine.Dice.Die2 },
+            BoardState = CreateBoardState(engine),
+            WhiteCheckersOnBar = engine.WhitePlayer.CheckersOnBar,
+            RedCheckersOnBar = engine.RedPlayer.CheckersOnBar,
+            WhiteBornOff = engine.WhitePlayer.CheckersBornOff,
+            RedBornOff = engine.RedPlayer.CheckersBornOff,
+            BestMoves = bestMove.Moves.Select(m => new MoveDto
+            {
+                From = m.From,
+                To = m.To,
+                DieValue = m.DieValue,
+                IsHit = m.IsHit
+            }).ToList(),
+            BestMovesNotation = bestMove.Notation,
+            BestMoveEquity = bestMove.FinalEvaluation.Equity,
+            AlternativeMoves = GetAlternativeMoves(analysis, _settings.EquityTolerance),
+            EvaluatorType = _settings.EvaluatorType,
+            CreatedAt = DateTime.UtcNow
+        };
+
+        // Save to repository
+        await _puzzleRepository.SavePuzzleAsync(puzzle);
+
+        _logger.LogInformation(
+            "Created puzzle {PuzzleId} for date {Date} with {AlternativeCount} alternative moves",
+            puzzle.PuzzleId,
+            date,
+            puzzle.AlternativeMoves.Count);
+
+        return puzzle;
+    }
+
+    private (bool IsCorrect, double EquityLoss) EvaluateAnswer(DailyPuzzle puzzle, List<MoveDto> submittedMoves)
+    {
+        // Normalize the submitted moves for comparison
+        var submittedNotation = NormalizeMovesNotation(submittedMoves);
+        var bestNotation = NormalizeMovesNotation(puzzle.BestMoves);
+
+        // Check if matches best move exactly
+        if (submittedNotation == bestNotation)
+        {
+            return (true, 0);
+        }
+
+        // Check if matches any alternative move
+        foreach (var alt in puzzle.AlternativeMoves)
+        {
+            var altNotation = NormalizeMovesNotation(alt.Moves);
+            if (submittedNotation == altNotation)
+            {
+                return (true, alt.EquityLoss);
+            }
+        }
+
+        // Not correct - calculate equity loss
+        // For now, return a generic "wrong" equity loss
+        // In a more sophisticated implementation, we'd evaluate the submitted position
+        return (false, _settings.EquityTolerance + 0.01);
+    }
+
+    private string NormalizeMovesNotation(List<MoveDto> moves)
+    {
+        // Sort moves to handle equivalent move orders
+        var sorted = moves
+            .OrderByDescending(m => m.From)
+            .ThenByDescending(m => m.To)
+            .Select(m => $"{m.From}/{m.To}")
+            .ToList();
+
+        return string.Join(" ", sorted);
+    }
+
+    private string FormatMovesNotation(List<MoveDto> moves)
+    {
+        return string.Join(" ", moves.Select(m =>
+        {
+            var from = m.From == 0 ? "bar" : m.From.ToString();
+            var to = m.To == 25 || m.To == 0 ? "off" : m.To.ToString();
+            return $"{from}/{to}";
+        }));
+    }
+
+    private string GetFeedback(bool isCorrect, double equityLoss, int attemptCount)
+    {
+        if (!isCorrect)
+        {
+            return attemptCount < 3
+                ? "Not quite. Try again!"
+                : "Keep trying! Think about blots and primes.";
+        }
+
+        return Math.Abs(equityLoss) < 1e-6
+            ? (attemptCount == 1
+                ? "Perfect! You found the best move!"
+                : "Correct! That's the best move.")
+            : $"Good move! Within {equityLoss:F3} equity of optimal.";
+    }
+
+    private async Task<PuzzleStreakInfo> UpdateStreakAsync(string userId, string puzzleDate, bool isCorrect)
+    {
+        var streakInfo = await _puzzleRepository.GetStreakInfoAsync(userId)
+            ?? new PuzzleStreakInfo { UserId = userId };
+
+        // Only count attempts from the submission path (this method is only called after submission)
+        if (isCorrect)
+        {
+            streakInfo.TotalAttempts++;
+        }
+
+        if (isCorrect)
+        {
+            // Only count a solve and update streaks the first time this puzzle is solved
+            var isFirstSolveForThisPuzzle =
+                string.IsNullOrEmpty(streakInfo.LastSolvedDate) ||
+                !string.Equals(streakInfo.LastSolvedDate, puzzleDate, StringComparison.Ordinal);
+
+            if (isFirstSolveForThisPuzzle)
+            {
+                streakInfo.TotalSolved++;
+
+                // Check if this continues or starts a streak
+                if (string.IsNullOrEmpty(streakInfo.LastSolvedDate))
+                {
+                    // First puzzle ever solved
+                    streakInfo.CurrentStreak = 1;
+                }
+                else
+                {
+                    var lastSolved = DateTime.Parse(streakInfo.LastSolvedDate);
+                    var currentPuzzle = DateTime.Parse(puzzleDate);
+                    var daysDiff = (currentPuzzle - lastSolved).Days;
+
+                    if (daysDiff == 1)
+                    {
+                        // Consecutive day - continue streak
+                        streakInfo.CurrentStreak++;
+                    }
+                    else if (daysDiff > 1)
+                    {
+                        // Missed day(s) - reset streak
+                        streakInfo.CurrentStreak = 1;
+                    }
+
+                    // daysDiff == 0 means same day, don't change streak
+                }
+
+                // Update best streak
+                if (streakInfo.CurrentStreak > streakInfo.BestStreak)
+                {
+                    streakInfo.BestStreak = streakInfo.CurrentStreak;
+                }
+
+                streakInfo.LastSolvedDate = puzzleDate;
+            }
+        }
+
+        await _puzzleRepository.SaveStreakInfoAsync(streakInfo);
+        return streakInfo;
+    }
+
+    private List<AlternativeMove> GetAlternativeMoves(BestMovesAnalysis analysis, double tolerance)
+    {
+        var alternatives = new List<AlternativeMove>();
+
+        if (analysis.TopMoves.Count <= 1)
+        {
+            return alternatives;
+        }
+
+        var bestEquity = analysis.TopMoves[0].FinalEvaluation.Equity;
+
+        // Skip the first (best) move, include others within tolerance
+        foreach (var move in analysis.TopMoves.Skip(1))
+        {
+            var equityLoss = Math.Abs(bestEquity - move.FinalEvaluation.Equity);
+
+            if (equityLoss <= tolerance)
+            {
+                alternatives.Add(new AlternativeMove
+                {
+                    Moves = move.Moves.Select(m => new MoveDto
+                    {
+                        From = m.From,
+                        To = m.To,
+                        DieValue = m.DieValue,
+                        IsHit = m.IsHit
+                    }).ToList(),
+                    Notation = move.Notation,
+                    Equity = move.FinalEvaluation.Equity,
+                    EquityLoss = equityLoss
+                });
+            }
+        }
+
+        return alternatives;
+    }
+
+    private List<PointStateDto> CreateBoardState(GameEngine engine)
+    {
+        var boardState = new List<PointStateDto>();
+
+        for (int i = 1; i <= 24; i++)
+        {
+            var point = engine.Board.GetPoint(i);
+            boardState.Add(new PointStateDto
+            {
+                Position = i,
+                Color = point.Color?.ToString(),
+                Count = point.Count
+            });
+        }
+
+        return boardState;
+    }
+
+    private DailyPuzzleDto MapToDto(DailyPuzzle puzzle, PuzzleAttempt? attempt)
+    {
+        var alreadySolved = attempt?.IsCorrect == true;
+
+        return new DailyPuzzleDto
+        {
+            PuzzleId = puzzle.PuzzleId,
+            PuzzleDate = puzzle.PuzzleDate,
+            CurrentPlayer = puzzle.CurrentPlayer,
+            Dice = puzzle.Dice,
+            BoardState = puzzle.BoardState,
+            WhiteCheckersOnBar = puzzle.WhiteCheckersOnBar,
+            RedCheckersOnBar = puzzle.RedCheckersOnBar,
+            WhiteBornOff = puzzle.WhiteBornOff,
+            RedBornOff = puzzle.RedBornOff,
+            AlreadySolved = alreadySolved,
+            AttemptsToday = attempt?.AttemptCount ?? 0,
+            // Only reveal best moves if already solved
+            BestMoves = alreadySolved ? puzzle.BestMoves : null,
+            BestMovesNotation = alreadySolved ? puzzle.BestMovesNotation : null
+        };
+    }
+}

--- a/Backgammon.Server/Services/DynamoDb/DynamoDbPuzzleRepository.cs
+++ b/Backgammon.Server/Services/DynamoDb/DynamoDbPuzzleRepository.cs
@@ -1,0 +1,535 @@
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.Model;
+using Backgammon.Server.Models;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Backgammon.Server.Services.DynamoDb;
+
+/// <summary>
+/// DynamoDB implementation of the puzzle repository.
+/// Uses single-table design with:
+/// - Puzzles: PK=PUZZLE#{date}, SK=METADATA
+/// - Attempts: PK=USER#{userId}, SK=PUZZLE_ATTEMPT#{date}
+/// - Streaks: PK=USER#{userId}, SK=PUZZLE_STREAK
+/// </summary>
+public class DynamoDbPuzzleRepository : IPuzzleRepository
+{
+    private readonly IAmazonDynamoDB _dynamoDbClient;
+    private readonly string _tableName;
+    private readonly ILogger<DynamoDbPuzzleRepository> _logger;
+
+    public DynamoDbPuzzleRepository(
+        IAmazonDynamoDB dynamoDbClient,
+        IConfiguration configuration,
+        ILogger<DynamoDbPuzzleRepository> logger)
+    {
+        _dynamoDbClient = dynamoDbClient;
+        _tableName = configuration["DynamoDb:TableName"] ?? "backgammon-local";
+        _logger = logger;
+    }
+
+    public async Task SavePuzzleAsync(DailyPuzzle puzzle)
+    {
+        try
+        {
+            var item = MarshalPuzzle(puzzle);
+
+            await _dynamoDbClient.PutItemAsync(new PutItemRequest
+            {
+                TableName = _tableName,
+                Item = item,
+                ConditionExpression = "attribute_not_exists(PK)"
+            });
+
+            _logger.LogInformation("Created puzzle for date {PuzzleDate}", puzzle.PuzzleDate);
+        }
+        catch (ConditionalCheckFailedException)
+        {
+            _logger.LogWarning("Puzzle for date {PuzzleDate} already exists", puzzle.PuzzleDate);
+            throw new InvalidOperationException($"Puzzle for {puzzle.PuzzleDate} already exists");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to save puzzle for date {PuzzleDate}", puzzle.PuzzleDate);
+            throw;
+        }
+    }
+
+    public async Task<DailyPuzzle?> GetPuzzleByDateAsync(string date)
+    {
+        try
+        {
+            var response = await _dynamoDbClient.GetItemAsync(new GetItemRequest
+            {
+                TableName = _tableName,
+                Key = new Dictionary<string, AttributeValue>
+                {
+                    ["PK"] = new AttributeValue { S = $"PUZZLE#{date}" },
+                    ["SK"] = new AttributeValue { S = "METADATA" }
+                }
+            });
+
+            if (!response.IsItemSet)
+            {
+                return null;
+            }
+
+            return UnmarshalPuzzle(response.Item);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get puzzle for date {Date}", date);
+            return null;
+        }
+    }
+
+    public async Task<bool> PuzzleExistsAsync(string date)
+    {
+        try
+        {
+            var response = await _dynamoDbClient.GetItemAsync(new GetItemRequest
+            {
+                TableName = _tableName,
+                Key = new Dictionary<string, AttributeValue>
+                {
+                    ["PK"] = new AttributeValue { S = $"PUZZLE#{date}" },
+                    ["SK"] = new AttributeValue { S = "METADATA" }
+                },
+                ProjectionExpression = "PK"
+            });
+
+            return response.IsItemSet;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to check if puzzle exists for date {Date}", date);
+            return false;
+        }
+    }
+
+    public async Task IncrementSolvedCountAsync(string puzzleDate)
+    {
+        try
+        {
+            await _dynamoDbClient.UpdateItemAsync(new UpdateItemRequest
+            {
+                TableName = _tableName,
+                Key = new Dictionary<string, AttributeValue>
+                {
+                    ["PK"] = new AttributeValue { S = $"PUZZLE#{puzzleDate}" },
+                    ["SK"] = new AttributeValue { S = "METADATA" }
+                },
+                UpdateExpression = "SET solvedCount = if_not_exists(solvedCount, :zero) + :one",
+                ExpressionAttributeValues = new Dictionary<string, AttributeValue>
+                {
+                    [":zero"] = new AttributeValue { N = "0" },
+                    [":one"] = new AttributeValue { N = "1" }
+                }
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to increment solved count for puzzle {PuzzleDate}", puzzleDate);
+            throw;
+        }
+    }
+
+    public async Task IncrementAttemptCountAsync(string puzzleDate)
+    {
+        try
+        {
+            await _dynamoDbClient.UpdateItemAsync(new UpdateItemRequest
+            {
+                TableName = _tableName,
+                Key = new Dictionary<string, AttributeValue>
+                {
+                    ["PK"] = new AttributeValue { S = $"PUZZLE#{puzzleDate}" },
+                    ["SK"] = new AttributeValue { S = "METADATA" }
+                },
+                UpdateExpression = "SET attemptCount = if_not_exists(attemptCount, :zero) + :one",
+                ExpressionAttributeValues = new Dictionary<string, AttributeValue>
+                {
+                    [":zero"] = new AttributeValue { N = "0" },
+                    [":one"] = new AttributeValue { N = "1" }
+                }
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to increment attempt count for puzzle {PuzzleDate}", puzzleDate);
+            throw;
+        }
+    }
+
+    public async Task SaveAttemptAsync(PuzzleAttempt attempt)
+    {
+        try
+        {
+            var item = MarshalAttempt(attempt);
+
+            await _dynamoDbClient.PutItemAsync(new PutItemRequest
+            {
+                TableName = _tableName,
+                Item = item
+            });
+
+            _logger.LogDebug(
+                "Saved attempt for user {UserId} on puzzle {PuzzleDate}",
+                attempt.UserId,
+                attempt.PuzzleDate);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Failed to save attempt for user {UserId} on puzzle {PuzzleDate}",
+                attempt.UserId,
+                attempt.PuzzleDate);
+            throw;
+        }
+    }
+
+    public async Task<PuzzleAttempt?> GetAttemptAsync(string userId, string puzzleDate)
+    {
+        try
+        {
+            var response = await _dynamoDbClient.GetItemAsync(new GetItemRequest
+            {
+                TableName = _tableName,
+                Key = new Dictionary<string, AttributeValue>
+                {
+                    ["PK"] = new AttributeValue { S = $"USER#{userId}" },
+                    ["SK"] = new AttributeValue { S = $"PUZZLE_ATTEMPT#{puzzleDate}" }
+                }
+            });
+
+            if (!response.IsItemSet)
+            {
+                return null;
+            }
+
+            return UnmarshalAttempt(response.Item);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Failed to get attempt for user {UserId} on puzzle {PuzzleDate}",
+                userId,
+                puzzleDate);
+            return null;
+        }
+    }
+
+    public async Task UpdateAttemptAsync(PuzzleAttempt attempt)
+    {
+        // For simplicity, just overwrite the entire item
+        await SaveAttemptAsync(attempt);
+    }
+
+    public async Task<PuzzleStreakInfo?> GetStreakInfoAsync(string userId)
+    {
+        try
+        {
+            var response = await _dynamoDbClient.GetItemAsync(new GetItemRequest
+            {
+                TableName = _tableName,
+                Key = new Dictionary<string, AttributeValue>
+                {
+                    ["PK"] = new AttributeValue { S = $"USER#{userId}" },
+                    ["SK"] = new AttributeValue { S = "PUZZLE_STREAK" }
+                }
+            });
+
+            if (!response.IsItemSet)
+            {
+                return null;
+            }
+
+            return UnmarshalStreakInfo(response.Item);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get streak info for user {UserId}", userId);
+            return null;
+        }
+    }
+
+    public async Task SaveStreakInfoAsync(PuzzleStreakInfo streakInfo)
+    {
+        try
+        {
+            var item = MarshalStreakInfo(streakInfo);
+
+            await _dynamoDbClient.PutItemAsync(new PutItemRequest
+            {
+                TableName = _tableName,
+                Item = item
+            });
+
+            _logger.LogDebug(
+                "Saved streak info for user {UserId}: streak={Streak}",
+                streakInfo.UserId,
+                streakInfo.CurrentStreak);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to save streak info for user {UserId}", streakInfo.UserId);
+            throw;
+        }
+    }
+
+    private static Dictionary<string, AttributeValue> MarshalPuzzle(DailyPuzzle puzzle)
+    {
+        var item = new Dictionary<string, AttributeValue>
+        {
+            ["PK"] = new AttributeValue { S = $"PUZZLE#{puzzle.PuzzleDate}" },
+            ["SK"] = new AttributeValue { S = "METADATA" },
+            ["puzzleId"] = new AttributeValue { S = puzzle.PuzzleId },
+            ["puzzleDate"] = new AttributeValue { S = puzzle.PuzzleDate },
+            ["positionSgf"] = new AttributeValue { S = puzzle.PositionSgf },
+            ["currentPlayer"] = new AttributeValue { S = puzzle.CurrentPlayer },
+            ["dice"] = new AttributeValue
+            {
+                L = puzzle.Dice.Select(d => new AttributeValue { N = d.ToString() }).ToList()
+            },
+            ["boardState"] = MarshalBoardState(puzzle.BoardState),
+            ["whiteCheckersOnBar"] = new AttributeValue { N = puzzle.WhiteCheckersOnBar.ToString() },
+            ["redCheckersOnBar"] = new AttributeValue { N = puzzle.RedCheckersOnBar.ToString() },
+            ["whiteBornOff"] = new AttributeValue { N = puzzle.WhiteBornOff.ToString() },
+            ["redBornOff"] = new AttributeValue { N = puzzle.RedBornOff.ToString() },
+            ["bestMoves"] = MarshalMoves(puzzle.BestMoves),
+            ["bestMovesNotation"] = new AttributeValue { S = puzzle.BestMovesNotation },
+            ["bestMoveEquity"] = new AttributeValue { N = puzzle.BestMoveEquity.ToString() },
+            ["alternativeMoves"] = MarshalAlternativeMoves(puzzle.AlternativeMoves),
+            ["evaluatorType"] = new AttributeValue { S = puzzle.EvaluatorType },
+            ["createdAt"] = new AttributeValue { S = puzzle.CreatedAt.ToString("O") },
+            ["solvedCount"] = new AttributeValue { N = puzzle.SolvedCount.ToString() },
+            ["attemptCount"] = new AttributeValue { N = puzzle.AttemptCount.ToString() },
+            ["entityType"] = new AttributeValue { S = "PUZZLE" }
+        };
+
+        return item;
+    }
+
+    private static DailyPuzzle UnmarshalPuzzle(Dictionary<string, AttributeValue> item)
+    {
+        return new DailyPuzzle
+        {
+            PuzzleId = DynamoDbHelpers.GetStringOrNull(item, "puzzleId") ?? string.Empty,
+            PuzzleDate = DynamoDbHelpers.GetStringOrNull(item, "puzzleDate") ?? string.Empty,
+            PositionSgf = DynamoDbHelpers.GetStringOrNull(item, "positionSgf") ?? string.Empty,
+            CurrentPlayer = DynamoDbHelpers.GetStringOrNull(item, "currentPlayer") ?? "White",
+            Dice = UnmarshalDice(item),
+            BoardState = UnmarshalBoardState(item),
+            WhiteCheckersOnBar = DynamoDbHelpers.GetInt(item, "whiteCheckersOnBar"),
+            RedCheckersOnBar = DynamoDbHelpers.GetInt(item, "redCheckersOnBar"),
+            WhiteBornOff = DynamoDbHelpers.GetInt(item, "whiteBornOff"),
+            RedBornOff = DynamoDbHelpers.GetInt(item, "redBornOff"),
+            BestMoves = UnmarshalMoves(item, "bestMoves"),
+            BestMovesNotation = DynamoDbHelpers.GetStringOrNull(item, "bestMovesNotation") ?? string.Empty,
+            BestMoveEquity = GetDouble(item, "bestMoveEquity"),
+            AlternativeMoves = UnmarshalAlternativeMoves(item),
+            EvaluatorType = DynamoDbHelpers.GetStringOrNull(item, "evaluatorType") ?? string.Empty,
+            CreatedAt = DynamoDbHelpers.GetDateTime(item, "createdAt"),
+            SolvedCount = DynamoDbHelpers.GetInt(item, "solvedCount"),
+            AttemptCount = DynamoDbHelpers.GetInt(item, "attemptCount")
+        };
+    }
+
+    private static Dictionary<string, AttributeValue> MarshalAttempt(PuzzleAttempt attempt)
+    {
+        var item = new Dictionary<string, AttributeValue>
+        {
+            ["PK"] = new AttributeValue { S = $"USER#{attempt.UserId}" },
+            ["SK"] = new AttributeValue { S = $"PUZZLE_ATTEMPT#{attempt.PuzzleDate}" },
+            ["userId"] = new AttributeValue { S = attempt.UserId },
+            ["puzzleId"] = new AttributeValue { S = attempt.PuzzleId },
+            ["puzzleDate"] = new AttributeValue { S = attempt.PuzzleDate },
+            ["submittedMoves"] = MarshalMoves(attempt.SubmittedMoves),
+            ["submittedNotation"] = new AttributeValue { S = attempt.SubmittedNotation },
+            ["isCorrect"] = new AttributeValue { BOOL = attempt.IsCorrect },
+            ["equityLoss"] = new AttributeValue { N = attempt.EquityLoss.ToString() },
+            ["attemptCount"] = new AttributeValue { N = attempt.AttemptCount.ToString() },
+            ["createdAt"] = new AttributeValue { S = attempt.CreatedAt.ToString("O") },
+            ["entityType"] = new AttributeValue { S = "PUZZLE_ATTEMPT" }
+        };
+
+        if (attempt.SolvedAt.HasValue)
+        {
+            item["solvedAt"] = new AttributeValue { S = attempt.SolvedAt.Value.ToString("O") };
+        }
+
+        return item;
+    }
+
+    private static PuzzleAttempt UnmarshalAttempt(Dictionary<string, AttributeValue> item)
+    {
+        return new PuzzleAttempt
+        {
+            UserId = DynamoDbHelpers.GetStringOrNull(item, "userId") ?? string.Empty,
+            PuzzleId = DynamoDbHelpers.GetStringOrNull(item, "puzzleId") ?? string.Empty,
+            PuzzleDate = DynamoDbHelpers.GetStringOrNull(item, "puzzleDate") ?? string.Empty,
+            SubmittedMoves = UnmarshalMoves(item, "submittedMoves"),
+            SubmittedNotation = DynamoDbHelpers.GetStringOrNull(item, "submittedNotation") ?? string.Empty,
+            IsCorrect = DynamoDbHelpers.GetBool(item, "isCorrect"),
+            EquityLoss = GetDouble(item, "equityLoss"),
+            AttemptCount = DynamoDbHelpers.GetInt(item, "attemptCount"),
+            CreatedAt = DynamoDbHelpers.GetDateTime(item, "createdAt"),
+            SolvedAt = DynamoDbHelpers.GetNullableDateTime(item, "solvedAt")
+        };
+    }
+
+    private static Dictionary<string, AttributeValue> MarshalStreakInfo(PuzzleStreakInfo info)
+    {
+        var item = new Dictionary<string, AttributeValue>
+        {
+            ["PK"] = new AttributeValue { S = $"USER#{info.UserId}" },
+            ["SK"] = new AttributeValue { S = "PUZZLE_STREAK" },
+            ["userId"] = new AttributeValue { S = info.UserId },
+            ["currentStreak"] = new AttributeValue { N = info.CurrentStreak.ToString() },
+            ["bestStreak"] = new AttributeValue { N = info.BestStreak.ToString() },
+            ["totalSolved"] = new AttributeValue { N = info.TotalSolved.ToString() },
+            ["totalAttempts"] = new AttributeValue { N = info.TotalAttempts.ToString() },
+            ["entityType"] = new AttributeValue { S = "PUZZLE_STREAK" }
+        };
+
+        if (!string.IsNullOrEmpty(info.LastSolvedDate))
+        {
+            item["lastSolvedDate"] = new AttributeValue { S = info.LastSolvedDate };
+        }
+
+        return item;
+    }
+
+    private static PuzzleStreakInfo UnmarshalStreakInfo(Dictionary<string, AttributeValue> item)
+    {
+        return new PuzzleStreakInfo
+        {
+            UserId = DynamoDbHelpers.GetStringOrNull(item, "userId") ?? string.Empty,
+            CurrentStreak = DynamoDbHelpers.GetInt(item, "currentStreak"),
+            BestStreak = DynamoDbHelpers.GetInt(item, "bestStreak"),
+            LastSolvedDate = DynamoDbHelpers.GetStringOrNull(item, "lastSolvedDate"),
+            TotalSolved = DynamoDbHelpers.GetInt(item, "totalSolved"),
+            TotalAttempts = DynamoDbHelpers.GetInt(item, "totalAttempts")
+        };
+    }
+
+    private static AttributeValue MarshalBoardState(List<PointStateDto> boardState)
+    {
+        return new AttributeValue
+        {
+            L = boardState.Select(p => new AttributeValue
+            {
+                M = new Dictionary<string, AttributeValue>
+                {
+                    ["position"] = new AttributeValue { N = p.Position.ToString() },
+                    ["color"] = p.Color != null ? new AttributeValue { S = p.Color } : new AttributeValue { NULL = true },
+                    ["count"] = new AttributeValue { N = p.Count.ToString() }
+                }
+            }).ToList()
+        };
+    }
+
+    private static List<PointStateDto> UnmarshalBoardState(Dictionary<string, AttributeValue> item)
+    {
+        if (!item.TryGetValue("boardState", out var value) || value.L == null)
+        {
+            return new List<PointStateDto>();
+        }
+
+        return value.L.Select(p => new PointStateDto
+        {
+            Position = int.Parse(p.M["position"].N),
+            Color = p.M.TryGetValue("color", out var c) && c.NULL != true ? c.S : null,
+            Count = int.Parse(p.M["count"].N)
+        }).ToList();
+    }
+
+    private static AttributeValue MarshalMoves(List<MoveDto> moves)
+    {
+        return new AttributeValue
+        {
+            L = moves.Select(m => new AttributeValue
+            {
+                M = new Dictionary<string, AttributeValue>
+                {
+                    ["from"] = new AttributeValue { N = m.From.ToString() },
+                    ["to"] = new AttributeValue { N = m.To.ToString() },
+                    ["dieValue"] = new AttributeValue { N = m.DieValue.ToString() },
+                    ["isHit"] = new AttributeValue { BOOL = m.IsHit }
+                }
+            }).ToList()
+        };
+    }
+
+    private static List<MoveDto> UnmarshalMoves(Dictionary<string, AttributeValue> item, string key)
+    {
+        if (!item.TryGetValue(key, out var value) || value.L == null)
+        {
+            return new List<MoveDto>();
+        }
+
+        return value.L.Select(m => new MoveDto
+        {
+            From = int.Parse(m.M["from"].N),
+            To = int.Parse(m.M["to"].N),
+            DieValue = int.Parse(m.M["dieValue"].N),
+            IsHit = m.M.TryGetValue("isHit", out var h) && h.BOOL == true
+        }).ToList();
+    }
+
+    private static AttributeValue MarshalAlternativeMoves(List<AlternativeMove> alternatives)
+    {
+        return new AttributeValue
+        {
+            L = alternatives.Select(a => new AttributeValue
+            {
+                M = new Dictionary<string, AttributeValue>
+                {
+                    ["moves"] = MarshalMoves(a.Moves),
+                    ["notation"] = new AttributeValue { S = a.Notation },
+                    ["equity"] = new AttributeValue { N = a.Equity.ToString() },
+                    ["equityLoss"] = new AttributeValue { N = a.EquityLoss.ToString() }
+                }
+            }).ToList()
+        };
+    }
+
+    private static List<AlternativeMove> UnmarshalAlternativeMoves(Dictionary<string, AttributeValue> item)
+    {
+        if (!item.TryGetValue("alternativeMoves", out var value) || value.L == null)
+        {
+            return new List<AlternativeMove>();
+        }
+
+        return value.L.Select(a => new AlternativeMove
+        {
+            Moves = UnmarshalMoves(a.M, "moves"),
+            Notation = a.M.TryGetValue("notation", out var n) ? n.S : string.Empty,
+            Equity = a.M.TryGetValue("equity", out var e) && double.TryParse(e.N, out var eq) ? eq : 0,
+            EquityLoss = a.M.TryGetValue("equityLoss", out var el) && double.TryParse(el.N, out var loss) ? loss : 0
+        }).ToList();
+    }
+
+    private static int[] UnmarshalDice(Dictionary<string, AttributeValue> item)
+    {
+        if (!item.TryGetValue("dice", out var value) || value.L == null || value.L.Count < 2)
+        {
+            return new[] { 0, 0 };
+        }
+
+        return value.L.Select(d => int.Parse(d.N)).ToArray();
+    }
+
+    private static double GetDouble(Dictionary<string, AttributeValue> item, string key)
+    {
+        if (item.TryGetValue(key, out var value) && double.TryParse(value.N, out var result))
+        {
+            return result;
+        }
+
+        return 0;
+    }
+}

--- a/Backgammon.Server/Services/IDailyPuzzleService.cs
+++ b/Backgammon.Server/Services/IDailyPuzzleService.cs
@@ -1,0 +1,40 @@
+using Backgammon.Server.Models;
+
+namespace Backgammon.Server.Services;
+
+/// <summary>
+/// Service interface for daily puzzle operations.
+/// </summary>
+public interface IDailyPuzzleService
+{
+    /// <summary>
+    /// Get today's puzzle for a user.
+    /// Includes whether they've already solved it and their attempt count.
+    /// </summary>
+    Task<DailyPuzzleDto?> GetTodaysPuzzleAsync(string? userId);
+
+    /// <summary>
+    /// Get a puzzle for a specific date.
+    /// </summary>
+    Task<DailyPuzzleDto?> GetPuzzleByDateAsync(string date, string? userId);
+
+    /// <summary>
+    /// Submit an answer to a puzzle.
+    /// </summary>
+    Task<PuzzleResultDto> SubmitAnswerAsync(string userId, string puzzleDate, List<MoveDto> moves);
+
+    /// <summary>
+    /// Get user's streak information.
+    /// </summary>
+    Task<PuzzleStreakInfo> GetStreakInfoAsync(string userId);
+
+    /// <summary>
+    /// Generate and save a new puzzle for a specific date.
+    /// </summary>
+    Task<DailyPuzzle> GeneratePuzzleForDateAsync(string date);
+
+    /// <summary>
+    /// Check if a puzzle exists for a specific date.
+    /// </summary>
+    Task<bool> PuzzleExistsAsync(string date);
+}

--- a/Backgammon.Server/Services/IPuzzleRepository.cs
+++ b/Backgammon.Server/Services/IPuzzleRepository.cs
@@ -1,0 +1,59 @@
+using Backgammon.Server.Models;
+
+namespace Backgammon.Server.Services;
+
+/// <summary>
+/// Repository interface for daily puzzle persistence operations.
+/// </summary>
+public interface IPuzzleRepository
+{
+    /// <summary>
+    /// Save a new daily puzzle.
+    /// </summary>
+    Task SavePuzzleAsync(DailyPuzzle puzzle);
+
+    /// <summary>
+    /// Get puzzle by date (yyyy-MM-dd format).
+    /// </summary>
+    Task<DailyPuzzle?> GetPuzzleByDateAsync(string date);
+
+    /// <summary>
+    /// Check if a puzzle exists for the given date.
+    /// </summary>
+    Task<bool> PuzzleExistsAsync(string date);
+
+    /// <summary>
+    /// Increment the solved count for a puzzle.
+    /// </summary>
+    Task IncrementSolvedCountAsync(string puzzleDate);
+
+    /// <summary>
+    /// Increment the attempt count for a puzzle.
+    /// </summary>
+    Task IncrementAttemptCountAsync(string puzzleDate);
+
+    /// <summary>
+    /// Save a user's puzzle attempt.
+    /// </summary>
+    Task SaveAttemptAsync(PuzzleAttempt attempt);
+
+    /// <summary>
+    /// Get a user's attempt for a specific puzzle date.
+    /// </summary>
+    Task<PuzzleAttempt?> GetAttemptAsync(string userId, string puzzleDate);
+
+    /// <summary>
+    /// Update an existing attempt (e.g., when user retries or solves).
+    /// </summary>
+    Task UpdateAttemptAsync(PuzzleAttempt attempt);
+
+    /// <summary>
+    /// Get user's puzzle streak info.
+    /// </summary>
+    Task<PuzzleStreakInfo?> GetStreakInfoAsync(string userId);
+
+    /// <summary>
+    /// Save or update user's puzzle streak info.
+    /// </summary>
+    Task SaveStreakInfoAsync(PuzzleStreakInfo streakInfo);
+}

--- a/Backgammon.Server/Services/RandomPositionGenerator.cs
+++ b/Backgammon.Server/Services/RandomPositionGenerator.cs
@@ -1,0 +1,517 @@
+using Backgammon.Core;
+using Microsoft.Extensions.Logging;
+
+namespace Backgammon.Server.Services;
+
+/// <summary>
+/// Generates random valid backgammon positions suitable for daily puzzles.
+/// Positions are designed to be interesting and have valid moves.
+/// </summary>
+public class RandomPositionGenerator
+{
+    private readonly ILogger<RandomPositionGenerator> _logger;
+
+    public RandomPositionGenerator(ILogger<RandomPositionGenerator> logger)
+    {
+        _logger = logger;
+    }
+
+    private enum GamePhase
+    {
+        Opening,
+        Midgame,
+        BearingOff,
+        Contact,
+    }
+
+    /// <summary>
+    /// Generate a valid random backgammon position with dice rolled.
+    /// The position will have valid moves available.
+    /// </summary>
+    /// <param name="maxAttempts">Maximum attempts before giving up (default 100).</param>
+    /// <returns>A GameEngine with a valid position and dice rolled.</returns>
+    public GameEngine GenerateRandomPosition(int maxAttempts = 100)
+    {
+        for (int attempt = 0; attempt < maxAttempts; attempt++)
+        {
+            var game = CreateRandomPosition();
+
+            if (game != null && ValidatePosition(game))
+            {
+                _logger.LogDebug("Generated valid position on attempt {Attempt}", attempt + 1);
+                return game;
+            }
+        }
+
+        // Fallback: return a simple known-good position
+        _logger.LogWarning(
+            "Failed to generate random position after {MaxAttempts} attempts, using fallback",
+            maxAttempts);
+        return CreateFallbackPosition();
+    }
+
+    private GameEngine? CreateRandomPosition()
+    {
+        try
+        {
+            var game = new GameEngine("White", "Red");
+            game.StartNewGame();
+
+            // Clear the standard starting position
+            ClearBoard(game);
+
+            // Select random game phase with weighted distribution
+            var phase = SelectRandomPhase();
+
+            // Generate position based on phase
+            switch (phase)
+            {
+                case GamePhase.Opening:
+                    GenerateOpeningPosition(game);
+                    break;
+                case GamePhase.Midgame:
+                    GenerateMidgamePosition(game);
+                    break;
+                case GamePhase.BearingOff:
+                    GenerateBearingOffPosition(game);
+                    break;
+                case GamePhase.Contact:
+                    GenerateContactPosition(game);
+                    break;
+            }
+
+            // Validate checker counts
+            if (!ValidateCheckerCounts(game))
+            {
+                return null;
+            }
+
+            // Roll dice and set up remaining moves
+            RollRandomDice(game);
+
+            // Set current player
+            var currentColor = Random.Shared.Next(2) == 0 ? CheckerColor.White : CheckerColor.Red;
+            game.SetCurrentPlayer(currentColor);
+
+            return game;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to create random position");
+            return null;
+        }
+    }
+
+    private GamePhase SelectRandomPhase()
+    {
+        // Weighted distribution: Midgame most common, then Contact, then BearingOff, Opening rare
+        var roll = Random.Shared.Next(100);
+        return roll switch
+        {
+            < 10 => GamePhase.Opening, // 10%
+            < 45 => GamePhase.Midgame, // 35%
+            < 70 => GamePhase.Contact, // 25%
+            _ => GamePhase.BearingOff // 30%
+        };
+    }
+
+    private void ClearBoard(GameEngine game)
+    {
+        for (int i = 1; i <= 24; i++)
+        {
+            game.Board.GetPoint(i).Checkers.Clear();
+        }
+
+        game.WhitePlayer.CheckersOnBar = 0;
+        game.RedPlayer.CheckersOnBar = 0;
+        game.WhitePlayer.CheckersBornOff = 0;
+        game.RedPlayer.CheckersBornOff = 0;
+    }
+
+    private void GenerateOpeningPosition(GameEngine game)
+    {
+        // Near-starting positions with some development
+        // White: mostly on 24, 13, 8, 6 with some moves made
+        // Red: mostly on 1, 12, 17, 19 with some moves made
+
+        // Place White checkers (home is 1-6, starting from 24 side)
+        PlaceCheckersWithVariation(game, CheckerColor.White, new[]
+        {
+            (24, 2, 1), // 1-2 on point 24
+            (13, 4, 2), // 3-5 on point 13
+            (8, 2, 2), // 1-3 on point 8
+            (6, 4, 2) // 3-5 on point 6
+        });
+
+        // Place Red checkers (home is 19-24, starting from 1 side)
+        PlaceCheckersWithVariation(game, CheckerColor.Red, new[]
+        {
+            (1, 2, 1), // 1-2 on point 1
+            (12, 4, 2), // 3-5 on point 12
+            (17, 2, 2), // 1-3 on point 17
+            (19, 4, 2) // 3-5 on point 19
+        });
+
+        // Add some variation by moving 1-3 checkers to random points
+        MakeRandomAdjustments(game, CheckerColor.White, 2);
+        MakeRandomAdjustments(game, CheckerColor.Red, 2);
+    }
+
+    private void GenerateMidgamePosition(GameEngine game)
+    {
+        // Midgame: checkers spread across the board, some contact
+        // White moving toward home (1-6), Red moving toward home (19-24)
+
+        // White: spread from midfield toward home
+        PlaceRandomCheckers(game, CheckerColor.White, 15, 1, 18);
+
+        // Red: spread from midfield toward their home
+        PlaceRandomCheckers(game, CheckerColor.Red, 15, 7, 24);
+
+        // Possibly add checkers on bar (25% chance)
+        if (Random.Shared.Next(4) == 0)
+        {
+            var barCount = Random.Shared.Next(1, 3);
+            game.WhitePlayer.CheckersOnBar = barCount;
+            // Remove from board to keep count at 15
+            RemoveRandomCheckers(game, CheckerColor.White, barCount);
+        }
+    }
+
+    private void GenerateBearingOffPosition(GameEngine game)
+    {
+        // Both players have all checkers in their home boards
+        // Some checkers may be borne off
+
+        // White home board: points 1-6
+        int whiteBornOff = Random.Shared.Next(0, 8); // 0-7 borne off
+        game.WhitePlayer.CheckersBornOff = whiteBornOff;
+        PlaceRandomCheckers(game, CheckerColor.White, 15 - whiteBornOff, 1, 6);
+
+        // Red home board: points 19-24
+        int redBornOff = Random.Shared.Next(0, 8);
+        game.RedPlayer.CheckersBornOff = redBornOff;
+        PlaceRandomCheckers(game, CheckerColor.Red, 15 - redBornOff, 19, 24);
+    }
+
+    private void GenerateContactPosition(GameEngine game)
+    {
+        // Both players have anchors in opponent's home, primes, etc.
+        // More complex tactical positions
+
+        // White: some checkers in red's home (19-24) as anchors, some in own home
+        PlaceCheckersWithDistribution(game, CheckerColor.White, new[]
+        {
+            (1, 6, 6), // 6 checkers in white home
+            (7, 12, 4), // 4 in midfield
+            (19, 24, 5) // 5 as anchors in red's home
+        });
+
+        // Red: some checkers in white's home (1-6) as anchors
+        PlaceCheckersWithDistribution(game, CheckerColor.Red, new[]
+        {
+            (19, 24, 6), // 6 in red home
+            (13, 18, 4), // 4 in midfield
+            (1, 6, 5) // 5 as anchors in white's home
+        });
+
+        // Maybe put someone on the bar
+        if (Random.Shared.Next(3) == 0)
+        {
+            game.WhitePlayer.CheckersOnBar = 1;
+            RemoveRandomCheckers(game, CheckerColor.White, 1);
+        }
+    }
+
+    /// <summary>
+    /// Place checkers with variation from base amounts.
+    /// </summary>
+    private void PlaceCheckersWithVariation(
+        GameEngine game,
+        CheckerColor color,
+        (int Point, int BaseCount, int Variation)[] placements)
+    {
+        foreach (var (point, baseCount, variation) in placements)
+        {
+            var count = Math.Max(0, baseCount + Random.Shared.Next(-variation, variation + 1));
+            for (int i = 0; i < count; i++)
+            {
+                var p = game.Board.GetPoint(point);
+                if (p.Color == null || p.Color == color)
+                {
+                    p.AddChecker(color);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Place checkers randomly within a range of points.
+    /// </summary>
+    private void PlaceRandomCheckers(GameEngine game, CheckerColor color, int count, int minPoint, int maxPoint)
+    {
+        int placed = 0;
+        int maxPerPoint = 6;
+        int attempts = 0;
+        int maxAttempts = count * 10;
+
+        while (placed < count && attempts < maxAttempts)
+        {
+            attempts++;
+            var point = Random.Shared.Next(minPoint, maxPoint + 1);
+            var p = game.Board.GetPoint(point);
+
+            // Only place if empty or same color, and not too stacked
+            if ((p.Color == null || p.Color == color) && p.Count < maxPerPoint)
+            {
+                p.AddChecker(color);
+                placed++;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Place checkers with specified distribution across ranges.
+    /// </summary>
+    private void PlaceCheckersWithDistribution(
+        GameEngine game,
+        CheckerColor color,
+        (int MinPoint, int MaxPoint, int Count)[] distributions)
+    {
+        foreach (var (minPoint, maxPoint, count) in distributions)
+        {
+            PlaceRandomCheckers(game, color, count, minPoint, maxPoint);
+        }
+    }
+
+    /// <summary>
+    /// Make small random adjustments to existing positions.
+    /// </summary>
+    private void MakeRandomAdjustments(GameEngine game, CheckerColor color, int adjustments)
+    {
+        for (int i = 0; i < adjustments; i++)
+        {
+            // Find a point with this color's checkers
+            var sourcePoint = FindRandomPointWithColor(game, color);
+            if (sourcePoint == null)
+            {
+                continue;
+            }
+
+            // Find a nearby valid destination
+            var destPointNum = Random.Shared.Next(1, 25);
+            var destPoint = game.Board.GetPoint(destPointNum);
+
+            // Move if valid (empty or same color) and source has checkers
+            if ((destPoint.Color == null || destPoint.Color == color) && sourcePoint.Count > 0)
+            {
+                sourcePoint.RemoveChecker();
+                destPoint.AddChecker(color);
+            }
+        }
+    }
+
+    private Point? FindRandomPointWithColor(GameEngine game, CheckerColor color)
+    {
+        var points = new List<Point>();
+        for (int i = 1; i <= 24; i++)
+        {
+            var p = game.Board.GetPoint(i);
+            // More than 1 to avoid stranding
+            if (p.Color == color && p.Count > 1)
+            {
+                points.Add(p);
+            }
+        }
+
+        return points.Count > 0 ? points[Random.Shared.Next(points.Count)] : null;
+    }
+
+    private void RemoveRandomCheckers(GameEngine game, CheckerColor color, int count)
+    {
+        int removed = 0;
+        int attempts = 0;
+
+        while (removed < count && attempts < 100)
+        {
+            attempts++;
+            var point = Random.Shared.Next(1, 25);
+            var p = game.Board.GetPoint(point);
+
+            if (p.Color == color && p.Count > 0)
+            {
+                p.RemoveChecker();
+                removed++;
+            }
+        }
+    }
+
+    private void RollRandomDice(GameEngine game)
+    {
+        var die1 = Random.Shared.Next(1, 7);
+        var die2 = Random.Shared.Next(1, 7);
+
+        game.Dice.SetDice(die1, die2);
+        game.RemainingMoves.Clear();
+        game.RemainingMoves.AddRange(game.Dice.GetMoves());
+    }
+
+    private bool ValidateCheckerCounts(GameEngine game)
+    {
+        // Count all white checkers
+        int whiteCount = game.WhitePlayer.CheckersOnBar + game.WhitePlayer.CheckersBornOff;
+        for (int i = 1; i <= 24; i++)
+        {
+            var p = game.Board.GetPoint(i);
+            if (p.Color == CheckerColor.White)
+            {
+                whiteCount += p.Count;
+            }
+        }
+
+        // Count all red checkers
+        int redCount = game.RedPlayer.CheckersOnBar + game.RedPlayer.CheckersBornOff;
+        for (int i = 1; i <= 24; i++)
+        {
+            var p = game.Board.GetPoint(i);
+            if (p.Color == CheckerColor.Red)
+            {
+                redCount += p.Count;
+            }
+        }
+
+        // Both must have exactly 15 checkers
+        if (whiteCount != 15 || redCount != 15)
+        {
+            _logger.LogDebug(
+                "Invalid checker counts: White={WhiteCount}, Red={RedCount}",
+                whiteCount,
+                redCount);
+
+            // Try to fix by adjusting
+            AdjustCheckerCount(game, CheckerColor.White, 15 - whiteCount);
+            AdjustCheckerCount(game, CheckerColor.Red, 15 - redCount);
+
+            // Re-validate
+            return ValidateCheckerCountsStrict(game);
+        }
+
+        return true;
+    }
+
+    private bool ValidateCheckerCountsStrict(GameEngine game)
+    {
+        int whiteCount = game.WhitePlayer.CheckersOnBar + game.WhitePlayer.CheckersBornOff;
+        int redCount = game.RedPlayer.CheckersOnBar + game.RedPlayer.CheckersBornOff;
+
+        for (int i = 1; i <= 24; i++)
+        {
+            var p = game.Board.GetPoint(i);
+            if (p.Color == CheckerColor.White)
+            {
+                whiteCount += p.Count;
+            }
+
+            if (p.Color == CheckerColor.Red)
+            {
+                redCount += p.Count;
+            }
+        }
+
+        return whiteCount == 15 && redCount == 15;
+    }
+
+    private void AdjustCheckerCount(GameEngine game, CheckerColor color, int adjustment)
+    {
+        if (adjustment > 0)
+        {
+            // Need to add checkers
+            PlaceRandomCheckers(game, color, adjustment, 1, 24);
+        }
+        else if (adjustment < 0)
+        {
+            // Need to remove checkers
+            RemoveRandomCheckers(game, color, -adjustment);
+        }
+    }
+
+    private bool ValidatePosition(GameEngine game)
+    {
+        // Must have exactly 15 checkers per side
+        if (!ValidateCheckerCountsStrict(game))
+        {
+            return false;
+        }
+
+        // Must have valid moves available
+        var validMoves = game.GetValidMoves();
+        if (validMoves.Count == 0)
+        {
+            _logger.LogDebug("Position has no valid moves");
+            return false;
+        }
+
+        return true;
+    }
+
+    private GameEngine CreateFallbackPosition()
+    {
+        // A known-good position that always has valid moves
+        var game = new GameEngine("White", "Red");
+        game.StartNewGame();
+
+        ClearBoard(game);
+
+        // Simple midgame position
+        // White: 2 on 24, 5 on 13, 3 on 8, 5 on 6
+        for (int i = 0; i < 2; i++)
+        {
+            game.Board.GetPoint(24).AddChecker(CheckerColor.White);
+        }
+
+        for (int i = 0; i < 5; i++)
+        {
+            game.Board.GetPoint(13).AddChecker(CheckerColor.White);
+        }
+
+        for (int i = 0; i < 3; i++)
+        {
+            game.Board.GetPoint(8).AddChecker(CheckerColor.White);
+        }
+
+        for (int i = 0; i < 5; i++)
+        {
+            game.Board.GetPoint(6).AddChecker(CheckerColor.White);
+        }
+
+        // Red: 2 on 1, 5 on 12, 3 on 17, 5 on 19
+        for (int i = 0; i < 2; i++)
+        {
+            game.Board.GetPoint(1).AddChecker(CheckerColor.Red);
+        }
+
+        for (int i = 0; i < 5; i++)
+        {
+            game.Board.GetPoint(12).AddChecker(CheckerColor.Red);
+        }
+
+        for (int i = 0; i < 3; i++)
+        {
+            game.Board.GetPoint(17).AddChecker(CheckerColor.Red);
+        }
+
+        for (int i = 0; i < 5; i++)
+        {
+            game.Board.GetPoint(19).AddChecker(CheckerColor.Red);
+        }
+
+        // Roll 6-4 - always has good moves
+        game.Dice.SetDice(6, 4);
+        game.RemainingMoves.Clear();
+        game.RemainingMoves.AddRange(game.Dice.GetMoves());
+
+        game.SetCurrentPlayer(CheckerColor.White);
+
+        return game;
+    }
+}

--- a/Backgammon.Server/appsettings.Development.json
+++ b/Backgammon.Server/appsettings.Development.json
@@ -14,5 +14,9 @@
   "Gnubg": {
     "ExecutablePath": "gnubg",
     "VerboseLogging": true
+  },
+  "Puzzle": {
+    "EvaluatorType": "Heuristic",
+    "EnableAutomaticGeneration": true
   }
 }

--- a/Backgammon.Server/appsettings.json
+++ b/Backgammon.Server/appsettings.json
@@ -64,5 +64,12 @@
   },
   "CorrespondenceTimeout": {
     "CheckIntervalHours": 1
+  },
+  "Puzzle": {
+    "EvaluatorType": "Gnubg",
+    "GnubgPlies": 2,
+    "EquityTolerance": 0.02,
+    "GenerationTimeUtc": "00:00:00",
+    "EnableAutomaticGeneration": true
   }
 }

--- a/Backgammon.WebClient/src/App.tsx
+++ b/Backgammon.WebClient/src/App.tsx
@@ -12,6 +12,7 @@ import { GamePage } from './pages/GamePage'
 import { ProfilePage } from './pages/ProfilePage'
 import { MatchResultsPage } from './pages/MatchResultsPage'
 import { AnalysisPage } from './pages/AnalysisPage'
+import { DailyPuzzlePage } from './pages/DailyPuzzlePage'
 import { NotFoundPage } from './pages/NotFoundPage'
 import { Toaster } from './components/ui/toaster'
 import { audioService } from './services/audio.service'
@@ -63,6 +64,7 @@ function AppContent() {
           <Route path="/profile/:username" element={<ProfilePage />} />
           <Route path="/match-results/:matchId" element={<MatchResultsPage />} />
           <Route path="/analysis/:sgf?" element={<AnalysisPage />} />
+          <Route path="/puzzle" element={<DailyPuzzlePage />} />
           <Route path="*" element={<NotFoundPage />} />
         </Routes>
       </Layout>

--- a/Backgammon.WebClient/src/components/home/DailyPuzzle.tsx
+++ b/Backgammon.WebClient/src/components/home/DailyPuzzle.tsx
@@ -1,9 +1,51 @@
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { Brain, Trophy } from "lucide-react";
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Brain, Trophy, Flame, Check, Loader2 } from 'lucide-react'
+import { useSignalR } from '@/contexts/SignalRContext'
+import { HubMethods } from '@/types/signalr.types'
+import { DailyPuzzle as DailyPuzzleType, PuzzleStreakInfo } from '@/types/puzzle.types'
 
 export function DailyPuzzle() {
+  const navigate = useNavigate()
+  const { invoke, isConnected } = useSignalR()
+  const [puzzle, setPuzzle] = useState<DailyPuzzleType | null>(null)
+  const [streak, setStreak] = useState<PuzzleStreakInfo | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    const loadPuzzlePreview = async () => {
+      if (!isConnected) return
+
+      try {
+        const [puzzleData, streakData] = await Promise.all([
+          invoke<DailyPuzzleType>(HubMethods.GetDailyPuzzle),
+          invoke<PuzzleStreakInfo>(HubMethods.GetPuzzleStreak),
+        ])
+        setPuzzle(puzzleData)
+        setStreak(streakData)
+      } catch (err) {
+        console.error('Failed to load puzzle preview:', err)
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    loadPuzzlePreview()
+  }, [isConnected, invoke])
+
+  const handleSolvePuzzle = () => {
+    navigate('/puzzle')
+  }
+
   return (
     <Card>
       <CardHeader>
@@ -15,30 +57,72 @@ export function DailyPuzzle() {
       </CardHeader>
       <CardContent className="space-y-4">
         <div className="relative bg-gradient-to-br from-purple-500/10 to-blue-500/10 rounded-lg p-6 border-2 border-dashed border-purple-500/30">
-          <div className="text-center space-y-2">
-            <Badge variant="secondary" className="mb-2">
-              Checker Play
-            </Badge>
-            <p className="text-sm text-muted-foreground">
-              You rolled 6-4. What's the best play?
-            </p>
-            <div className="text-xs text-muted-foreground mt-2">
-              Difficulty: ⭐⭐⭐
+          {isLoading ? (
+            <div className="flex items-center justify-center py-4">
+              <Loader2 className="h-6 w-6 animate-spin text-purple-500" />
             </div>
-          </div>
+          ) : puzzle ? (
+            <div className="text-center space-y-2">
+              <div className="flex items-center justify-center gap-2 mb-2">
+                <Badge variant="secondary">Checker Play</Badge>
+                {puzzle.alreadySolved && (
+                  <Badge variant="default" className="bg-green-600">
+                    <Check className="h-3 w-3 mr-1" />
+                    Solved
+                  </Badge>
+                )}
+              </div>
+              <p className="text-sm text-muted-foreground">
+                {puzzle.currentPlayer} rolled {puzzle.dice[0]}-{puzzle.dice[1]}.
+                What's the best play?
+              </p>
+              <p className="text-xs text-muted-foreground mt-2">
+                {puzzle.alreadySolved
+                  ? `Solved in ${puzzle.attemptsToday} attempt${puzzle.attemptsToday !== 1 ? 's' : ''}`
+                  : puzzle.attemptsToday > 0
+                  ? `${puzzle.attemptsToday} attempt${puzzle.attemptsToday !== 1 ? 's' : ''} today`
+                  : 'Not attempted yet'}
+              </p>
+            </div>
+          ) : (
+            <div className="text-center space-y-2">
+              <p className="text-sm text-muted-foreground">
+                No puzzle available today
+              </p>
+              <p className="text-xs text-muted-foreground">
+                Check back later!
+              </p>
+            </div>
+          )}
         </div>
-        
+
         <div className="flex items-center justify-between">
           <div className="text-sm">
             <p className="text-muted-foreground">Your streak</p>
-            <div className="flex items-center gap-1">
-              <Trophy className="h-4 w-4 text-yellow-500" />
-              <span className="font-semibold">12 days</span>
+            <div className="flex items-center gap-3">
+              {streak && streak.currentStreak > 0 ? (
+                <>
+                  <div className="flex items-center gap-1">
+                    <Flame className="h-4 w-4 text-orange-500" />
+                    <span className="font-semibold">{streak.currentStreak} days</span>
+                  </div>
+                  {streak.bestStreak > streak.currentStreak && (
+                    <div className="flex items-center gap-1 text-xs text-muted-foreground">
+                      <Trophy className="h-3 w-3 text-yellow-500" />
+                      <span>Best: {streak.bestStreak}</span>
+                    </div>
+                  )}
+                </>
+              ) : (
+                <span className="text-muted-foreground">Start your streak!</span>
+              )}
             </div>
           </div>
-          <Button>Solve Puzzle</Button>
+          <Button onClick={handleSolvePuzzle} disabled={!puzzle}>
+            {puzzle?.alreadySolved ? 'View Solution' : 'Solve Puzzle'}
+          </Button>
         </div>
       </CardContent>
     </Card>
-  );
+  )
 }

--- a/Backgammon.WebClient/src/components/puzzle/PuzzleBoard.tsx
+++ b/Backgammon.WebClient/src/components/puzzle/PuzzleBoard.tsx
@@ -1,0 +1,657 @@
+import { useRef, useCallback } from 'react'
+import { DailyPuzzle } from '@/types/puzzle.types'
+import { usePuzzleStore } from '@/stores/puzzleStore'
+import { useBoardDrag, BOARD_CONFIG, BOARD_COLORS } from '@/hooks/useBoardDrag'
+import { POINT_COORDS } from '@/lib/boardConstants'
+
+interface PuzzleBoardProps {
+  puzzle: DailyPuzzle
+}
+
+export function PuzzleBoard({ puzzle }: PuzzleBoardProps) {
+  const svgRef = useRef<SVGSVGElement>(null)
+  const {
+    selectedPoint,
+    validDestinations: clickValidDestinations,
+    pendingMoves,
+    remainingDice,
+    addMove,
+    setSelectedPoint,
+    setValidDestinations: setClickValidDestinations,
+  } = usePuzzleStore()
+
+  // Get board state with pending moves applied
+  const getBoardWithMoves = useCallback(() => {
+    // Start with original board state
+    const board = puzzle.boardState.map((p) => ({ ...p }))
+    let whiteOnBar = puzzle.whiteCheckersOnBar
+    let redOnBar = puzzle.redCheckersOnBar
+    let whiteBornOff = puzzle.whiteBornOff
+    let redBornOff = puzzle.redBornOff
+
+    // Apply pending moves
+    for (const move of pendingMoves) {
+      const movingColor = puzzle.currentPlayer
+
+      // Remove from source
+      if (move.from === 0) {
+        // From bar
+        if (movingColor === 'White') whiteOnBar--
+        else redOnBar--
+      } else {
+        const sourcePoint = board.find((p) => p.position === move.from)
+        if (sourcePoint && sourcePoint.count > 0) {
+          sourcePoint.count--
+          if (sourcePoint.count === 0) sourcePoint.color = null
+        }
+      }
+
+      // Add to destination
+      if (move.to === 0 || move.to === 25) {
+        // Bear off
+        if (movingColor === 'White') whiteBornOff++
+        else redBornOff++
+      } else {
+        const destPoint = board.find((p) => p.position === move.to)
+        if (destPoint) {
+          // Handle hit
+          if (move.isHit && destPoint.count === 1 && destPoint.color !== movingColor) {
+            if (destPoint.color === 'White') whiteOnBar++
+            else redOnBar++
+            destPoint.count = 0
+          }
+          destPoint.count++
+          destPoint.color = movingColor
+        }
+      }
+    }
+
+    return { board, whiteOnBar, redOnBar, whiteBornOff, redBornOff }
+  }, [puzzle, pendingMoves])
+
+  const { board, whiteOnBar, redOnBar, whiteBornOff, redBornOff } = getBoardWithMoves()
+
+  // Calculate valid moves from a point
+  const getValidMovesFrom = useCallback(
+    (from: number): number[] => {
+      if (remainingDice.length === 0) return []
+
+      const dests: number[] = []
+      const movingColor = puzzle.currentPlayer
+      const direction = movingColor === 'White' ? -1 : 1
+
+      // Check if player has checkers on bar - must enter first
+      const currentBoard = getBoardWithMoves()
+      const onBar = movingColor === 'White' ? currentBoard.whiteOnBar : currentBoard.redOnBar
+      if (onBar > 0 && from !== 0) {
+        return [] // Must move from bar first
+      }
+
+      for (const die of remainingDice) {
+        let to: number
+
+        if (from === 0) {
+          // Coming from bar
+          to = movingColor === 'White' ? 25 - die : die
+        } else {
+          to = from + direction * die
+        }
+
+        // Check if destination is valid
+        if (to >= 1 && to <= 24) {
+          const destPoint = currentBoard.board.find((p) => p.position === to)
+          if (destPoint) {
+            // Can land if empty, own color, or single opponent (blot)
+            if (
+              destPoint.color === null ||
+              destPoint.color === movingColor ||
+              (destPoint.color !== movingColor && destPoint.count === 1)
+            ) {
+              if (!dests.includes(to)) dests.push(to)
+            }
+          }
+        }
+
+        // Check bear off - only allowed if all checkers are in home board
+        const canBearOff = () => {
+          if (movingColor === 'White') {
+            // White's home board is points 1-6, must have no checkers on bar or points 7-24
+            if (currentBoard.whiteOnBar > 0) return false
+            for (const point of currentBoard.board) {
+              if (point.color === 'White' && point.position > 6) return false
+            }
+            return true
+          } else {
+            // Red's home board is points 19-24, must have no checkers on bar or points 1-18
+            if (currentBoard.redOnBar > 0) return false
+            for (const point of currentBoard.board) {
+              if (point.color === 'Red' && point.position < 19) return false
+            }
+            return true
+          }
+        }
+
+        if (movingColor === 'White' && to <= 0 && canBearOff()) {
+          if (!dests.includes(0)) dests.push(0)
+        } else if (movingColor === 'Red' && to >= 25 && canBearOff()) {
+          if (!dests.includes(25)) dests.push(25)
+        }
+      }
+
+      return dests
+    },
+    [puzzle.currentPlayer, remainingDice, getBoardWithMoves]
+  )
+
+  // Handle completing a move (from drag or click)
+  const handleMoveComplete = useCallback(
+    (from: number, to: number) => {
+      const currentPlayerColor = puzzle.currentPlayer
+      const direction = currentPlayerColor === 'White' ? -1 : 1
+      const destinations = getValidMovesFrom(from)
+
+      // Check if this is a valid destination
+      if (!destinations.includes(to)) return
+
+      // Find the actual die that matches
+      const matchingDie = remainingDice.find((d) => {
+        const expectedTo =
+          from === 0
+            ? currentPlayerColor === 'White'
+              ? 25 - d
+              : d
+            : from + direction * d
+        return (
+          expectedTo === to ||
+          (to === 0 && expectedTo <= 0) ||
+          (to === 25 && expectedTo >= 25)
+        )
+      })
+
+      if (matchingDie) {
+        // Check if this is a hit
+        const currentBoard = getBoardWithMoves()
+        const destPoint = currentBoard.board.find((p) => p.position === to)
+        const isHit =
+          destPoint &&
+          destPoint.color !== null &&
+          destPoint.color !== currentPlayerColor &&
+          destPoint.count === 1
+
+        addMove({
+          from,
+          to,
+          dieValue: matchingDie,
+          isHit: !!isHit,
+        })
+      }
+
+      // Clear selection
+      setSelectedPoint(null)
+      setClickValidDestinations([])
+    },
+    [
+      puzzle.currentPlayer,
+      remainingDice,
+      getValidMovesFrom,
+      getBoardWithMoves,
+      addMove,
+      setSelectedPoint,
+      setClickValidDestinations,
+    ]
+  )
+
+  // Initialize drag hook
+  const { dragState, validDestinations: dragValidDestinations, startDrag, ghostChecker } =
+    useBoardDrag({
+      svgRef,
+      isBoardFlipped: false,
+      onMoveComplete: handleMoveComplete,
+      getValidDestinations: getValidMovesFrom,
+    })
+
+  // Combined valid destinations (from drag or click selection)
+  const activeValidDestinations = dragState.isDragging
+    ? dragValidDestinations
+    : clickValidDestinations
+
+  // Handle point click (for click-to-move fallback)
+  const handlePointClick = (pointNum: number) => {
+    // Ignore clicks while dragging
+    if (dragState.isDragging) return
+
+    const currentPlayerColor = puzzle.currentPlayer
+
+    // If clicking on a valid destination
+    if (selectedPoint !== null && clickValidDestinations.includes(pointNum)) {
+      handleMoveComplete(selectedPoint, pointNum)
+      return
+    }
+
+    // Check if clicking on a source point with our checkers
+    const point = board.find((p) => p.position === pointNum)
+    if (point && point.color === currentPlayerColor && point.count > 0) {
+      // Check if player can move from this point (bar priority)
+      const destinations = getValidMovesFrom(pointNum)
+      if (destinations.length > 0) {
+        setSelectedPoint(pointNum)
+        setClickValidDestinations(destinations)
+      }
+    } else {
+      // Deselect
+      setSelectedPoint(null)
+      setClickValidDestinations([])
+    }
+  }
+
+  // Handle bar click
+  const handleBarClick = () => {
+    if (dragState.isDragging) return
+
+    const currentPlayerColor = puzzle.currentPlayer
+    const onBar = currentPlayerColor === 'White' ? whiteOnBar : redOnBar
+
+    if (onBar > 0) {
+      const destinations = getValidMovesFrom(0)
+      if (destinations.length > 0) {
+        setSelectedPoint(0)
+        setClickValidDestinations(destinations)
+      }
+    }
+  }
+
+  // Check if a checker is draggable
+  const isCheckerDraggable = (pointNum: number, color: string | null, isTopChecker: boolean) => {
+    if (!isTopChecker) return false
+    if (color !== puzzle.currentPlayer) return false
+    if (remainingDice.length === 0) return false
+
+    // Check bar priority
+    const onBar = puzzle.currentPlayer === 'White' ? whiteOnBar : redOnBar
+    if (onBar > 0 && pointNum !== 0) return false
+
+    return getValidMovesFrom(pointNum).length > 0
+  }
+
+  // Get point coordinates
+  const getPointCoords = (pointNum: number) => {
+    return POINT_COORDS[pointNum] || { x: 0, y: 0, direction: 1 }
+  }
+
+  // Render point triangle
+  const renderPoint = (pointNum: number) => {
+    const coords = getPointCoords(pointNum)
+    const isTop = coords.direction === 1
+    const isDark = (pointNum % 2 === 0) !== isTop
+
+    const points = isTop
+      ? `${coords.x},${coords.y} ${coords.x + BOARD_CONFIG.pointWidth / 2},${coords.y + BOARD_CONFIG.pointHeight} ${coords.x + BOARD_CONFIG.pointWidth},${coords.y}`
+      : `${coords.x},${coords.y} ${coords.x + BOARD_CONFIG.pointWidth / 2},${coords.y - BOARD_CONFIG.pointHeight} ${coords.x + BOARD_CONFIG.pointWidth},${coords.y}`
+
+    const point = board.find((p) => p.position === pointNum)
+    const isSelected = selectedPoint === pointNum || dragState.sourcePoint === pointNum
+    const isValidDest = activeValidDestinations.includes(pointNum)
+
+    // Check if destination would be a capture
+    const isCapture =
+      isValidDest &&
+      point &&
+      point.color !== null &&
+      point.color !== puzzle.currentPlayer &&
+      point.count === 1
+
+    // Determine fill color
+    let fillColor = isDark ? BOARD_COLORS.pointDark : BOARD_COLORS.pointLight
+    if (isSelected) {
+      fillColor = BOARD_COLORS.highlightSelected
+    } else if (isCapture) {
+      fillColor = BOARD_COLORS.highlightCapture
+    } else if (isValidDest) {
+      fillColor = BOARD_COLORS.highlightDest
+    }
+
+    return (
+      <g key={pointNum} onClick={() => handlePointClick(pointNum)} style={{ cursor: 'pointer' }}>
+        {/* Point triangle */}
+        <polygon points={points} fill={fillColor} />
+
+        {/* Checkers on this point */}
+        {point &&
+          point.count > 0 &&
+          renderCheckersOnPoint(pointNum, point.color!, point.count, coords, isTop)}
+
+        {/* Point number */}
+        <text
+          x={coords.x + BOARD_CONFIG.pointWidth / 2}
+          y={isTop ? coords.y - 8 : coords.y + 15}
+          textAnchor="middle"
+          fill={BOARD_COLORS.textLight}
+          fontSize="12"
+        >
+          {pointNum}
+        </text>
+      </g>
+    )
+  }
+
+  // Render checkers on a point
+  const renderCheckersOnPoint = (
+    pointNum: number,
+    color: string,
+    count: number,
+    coords: { x: number; y: number; direction: number },
+    isTop: boolean
+  ) => {
+    const maxVisible = Math.min(count, 5)
+    const checkerColor = color === 'White' ? BOARD_COLORS.checkerWhite : BOARD_COLORS.checkerRed
+    const strokeColor =
+      color === 'White' ? BOARD_COLORS.checkerWhiteStroke : BOARD_COLORS.checkerRedStroke
+
+    // If dragging from this point, reduce visible count by 1
+    const adjustedMaxVisible =
+      dragState.isDragging && dragState.sourcePoint === pointNum
+        ? Math.max(0, maxVisible - 1)
+        : maxVisible
+    const adjustedCount =
+      dragState.isDragging && dragState.sourcePoint === pointNum
+        ? Math.max(0, count - 1)
+        : count
+
+    return (
+      <>
+        {Array.from({ length: adjustedMaxVisible }).map((_, i) => {
+          const cy = isTop
+            ? coords.y + BOARD_CONFIG.checkerRadius + i * BOARD_CONFIG.checkerSpacing
+            : coords.y - BOARD_CONFIG.checkerRadius - i * BOARD_CONFIG.checkerSpacing
+          const cx = coords.x + BOARD_CONFIG.pointWidth / 2
+          const isTopChecker = i === adjustedMaxVisible - 1
+          const draggable = isCheckerDraggable(pointNum, color, isTopChecker)
+
+          return (
+            <circle
+              key={i}
+              cx={cx}
+              cy={cy}
+              r={BOARD_CONFIG.checkerRadius}
+              fill={checkerColor}
+              stroke={strokeColor}
+              strokeWidth={2}
+              style={{ cursor: draggable ? 'grab' : 'default' }}
+              onMouseDown={(e) => {
+                if (draggable) {
+                  startDrag(e, pointNum, color.toLowerCase() as 'white' | 'red')
+                }
+              }}
+              onTouchStart={(e) => {
+                if (draggable) {
+                  startDrag(e, pointNum, color.toLowerCase() as 'white' | 'red')
+                }
+              }}
+            />
+          )
+        })}
+        {/* Show count if more than 5 */}
+        {adjustedCount > 5 && (
+          <text
+            x={coords.x + BOARD_CONFIG.pointWidth / 2}
+            y={
+              isTop
+                ? coords.y + BOARD_CONFIG.checkerRadius + 4 * BOARD_CONFIG.checkerSpacing
+                : coords.y - BOARD_CONFIG.checkerRadius - 4 * BOARD_CONFIG.checkerSpacing
+            }
+            textAnchor="middle"
+            dominantBaseline="middle"
+            fill={color === 'White' ? '#333' : '#fff'}
+            fontSize="14"
+            fontWeight="bold"
+          >
+            {adjustedCount}
+          </text>
+        )}
+      </>
+    )
+  }
+
+  // Render bar checkers
+  const renderBar = () => {
+    const barX = BOARD_CONFIG.barX
+    const barY = BOARD_CONFIG.viewBox.height / 2
+    const currentPlayerColor = puzzle.currentPlayer
+    const currentOnBar = currentPlayerColor === 'White' ? whiteOnBar : redOnBar
+    const isBarSelected = selectedPoint === 0 || dragState.sourcePoint === 0
+
+    // Determine fill color
+    let barFill = BOARD_COLORS.bar
+    if (isBarSelected) {
+      barFill = BOARD_COLORS.highlightSelected
+    }
+
+    // Adjust white bar count if dragging from bar
+    const adjustedWhiteOnBar =
+      dragState.isDragging && dragState.sourcePoint === 0 && currentPlayerColor === 'White'
+        ? Math.max(0, whiteOnBar - 1)
+        : whiteOnBar
+    const adjustedRedOnBar =
+      dragState.isDragging && dragState.sourcePoint === 0 && currentPlayerColor === 'Red'
+        ? Math.max(0, redOnBar - 1)
+        : redOnBar
+
+    return (
+      <g onClick={handleBarClick} style={{ cursor: currentOnBar > 0 ? 'pointer' : 'default' }}>
+        {/* Bar background */}
+        <rect
+          x={barX}
+          y={BOARD_CONFIG.padding}
+          width={BOARD_CONFIG.barWidth}
+          height={BOARD_CONFIG.viewBox.height - 2 * BOARD_CONFIG.padding}
+          fill={barFill}
+        />
+
+        {/* White bar checkers (bottom of bar) */}
+        {adjustedWhiteOnBar > 0 && (
+          <>
+            <circle
+              cx={barX + BOARD_CONFIG.barWidth / 2}
+              cy={barY + 50}
+              r={BOARD_CONFIG.checkerRadius}
+              fill={BOARD_COLORS.checkerWhite}
+              stroke={BOARD_COLORS.checkerWhiteStroke}
+              strokeWidth={2}
+              style={{
+                cursor: isCheckerDraggable(0, 'White', true) ? 'grab' : 'default',
+              }}
+              onMouseDown={(e) => {
+                if (isCheckerDraggable(0, 'White', true)) {
+                  startDrag(e, 0, 'white')
+                }
+              }}
+              onTouchStart={(e) => {
+                if (isCheckerDraggable(0, 'White', true)) {
+                  startDrag(e, 0, 'white')
+                }
+              }}
+            />
+            {adjustedWhiteOnBar > 1 && (
+              <text
+                x={barX + BOARD_CONFIG.barWidth / 2}
+                y={barY + 50}
+                textAnchor="middle"
+                dominantBaseline="middle"
+                fill="#333"
+                fontSize="14"
+                fontWeight="bold"
+              >
+                {adjustedWhiteOnBar}
+              </text>
+            )}
+          </>
+        )}
+
+        {/* Red bar checkers (top of bar) */}
+        {adjustedRedOnBar > 0 && (
+          <>
+            <circle
+              cx={barX + BOARD_CONFIG.barWidth / 2}
+              cy={barY - 50}
+              r={BOARD_CONFIG.checkerRadius}
+              fill={BOARD_COLORS.checkerRed}
+              stroke={BOARD_COLORS.checkerRedStroke}
+              strokeWidth={2}
+              style={{
+                cursor: isCheckerDraggable(0, 'Red', true) ? 'grab' : 'default',
+              }}
+              onMouseDown={(e) => {
+                if (isCheckerDraggable(0, 'Red', true)) {
+                  startDrag(e, 0, 'red')
+                }
+              }}
+              onTouchStart={(e) => {
+                if (isCheckerDraggable(0, 'Red', true)) {
+                  startDrag(e, 0, 'red')
+                }
+              }}
+            />
+            {adjustedRedOnBar > 1 && (
+              <text
+                x={barX + BOARD_CONFIG.barWidth / 2}
+                y={barY - 50}
+                textAnchor="middle"
+                dominantBaseline="middle"
+                fill="#fff"
+                fontSize="14"
+                fontWeight="bold"
+              >
+                {adjustedRedOnBar}
+              </text>
+            )}
+          </>
+        )}
+      </g>
+    )
+  }
+
+  // Render bear off area
+  const renderBearoff = () => {
+    const rightEdge = BOARD_CONFIG.viewBox.width - BOARD_CONFIG.margin
+    const bearoffX = rightEdge - BOARD_CONFIG.bearoffWidth
+    const isWhiteDest = activeValidDestinations.includes(0) && puzzle.currentPlayer === 'White'
+    const isRedDest = activeValidDestinations.includes(25) && puzzle.currentPlayer === 'Red'
+
+    return (
+      <>
+        {/* White bear off (bottom) */}
+        <g
+          onClick={() => isWhiteDest && handleMoveComplete(selectedPoint ?? dragState.sourcePoint ?? 0, 0)}
+          style={{ cursor: isWhiteDest ? 'pointer' : 'default' }}
+        >
+          <rect
+            x={bearoffX}
+            y={BOARD_CONFIG.viewBox.height / 2 + 10}
+            width={BOARD_CONFIG.bearoffWidth}
+            height={BOARD_CONFIG.viewBox.height / 2 - BOARD_CONFIG.padding - 10}
+            fill={isWhiteDest ? BOARD_COLORS.highlightDest : BOARD_COLORS.bearoff}
+          />
+          {whiteBornOff > 0 && (
+            <text
+              x={bearoffX + BOARD_CONFIG.bearoffWidth / 2}
+              y={BOARD_CONFIG.viewBox.height - 50}
+              textAnchor="middle"
+              fill={BOARD_COLORS.checkerWhite}
+              fontSize="18"
+              fontWeight="bold"
+            >
+              {whiteBornOff}
+            </text>
+          )}
+        </g>
+
+        {/* Red bear off (top) */}
+        <g
+          onClick={() => isRedDest && handleMoveComplete(selectedPoint ?? dragState.sourcePoint ?? 0, 25)}
+          style={{ cursor: isRedDest ? 'pointer' : 'default' }}
+        >
+          <rect
+            x={bearoffX}
+            y={BOARD_CONFIG.padding}
+            width={BOARD_CONFIG.bearoffWidth}
+            height={BOARD_CONFIG.viewBox.height / 2 - BOARD_CONFIG.padding - 10}
+            fill={isRedDest ? BOARD_COLORS.highlightDest : BOARD_COLORS.bearoff}
+          />
+          {redBornOff > 0 && (
+            <text
+              x={bearoffX + BOARD_CONFIG.bearoffWidth / 2}
+              y={50}
+              textAnchor="middle"
+              fill={BOARD_COLORS.checkerRed}
+              fontSize="18"
+              fontWeight="bold"
+            >
+              {redBornOff}
+            </text>
+          )}
+        </g>
+      </>
+    )
+  }
+
+  // Render ghost checker (during drag)
+  const renderGhostChecker = () => {
+    if (!ghostChecker) return null
+
+    const checkerColor =
+      ghostChecker.color === 'white' ? BOARD_COLORS.checkerWhite : BOARD_COLORS.checkerRed
+    const strokeColor =
+      ghostChecker.color === 'white'
+        ? BOARD_COLORS.checkerWhiteStroke
+        : BOARD_COLORS.checkerRedStroke
+
+    return (
+      <circle
+        cx={ghostChecker.x}
+        cy={ghostChecker.y}
+        r={BOARD_CONFIG.checkerRadius}
+        fill={checkerColor}
+        stroke={strokeColor}
+        strokeWidth={2}
+        opacity={0.7}
+        pointerEvents="none"
+        style={{ filter: 'drop-shadow(0 4px 6px rgba(0,0,0,0.3))' }}
+      />
+    )
+  }
+
+  return (
+    <div className="w-full aspect-[2/1] bg-background rounded-lg overflow-hidden">
+      <svg
+        ref={svgRef}
+        viewBox={`0 0 ${BOARD_CONFIG.viewBox.width} ${BOARD_CONFIG.viewBox.height}`}
+        className="w-full h-full"
+        preserveAspectRatio="xMidYMid meet"
+      >
+        {/* Board background */}
+        <rect
+          x={BOARD_CONFIG.margin}
+          y={BOARD_CONFIG.margin}
+          width={BOARD_CONFIG.viewBox.width - 2 * BOARD_CONFIG.margin}
+          height={BOARD_CONFIG.viewBox.height - 2 * BOARD_CONFIG.margin}
+          fill={BOARD_COLORS.boardBackground}
+          stroke={BOARD_COLORS.boardBorder}
+          strokeWidth={2}
+          rx={8}
+        />
+
+        {/* Render points */}
+        {Array.from({ length: 24 }, (_, i) => i + 1).map(renderPoint)}
+
+        {/* Render bar */}
+        {renderBar()}
+
+        {/* Render bear off areas */}
+        {renderBearoff()}
+
+        {/* Render ghost checker during drag */}
+        {renderGhostChecker()}
+      </svg>
+    </div>
+  )
+}

--- a/Backgammon.WebClient/src/components/puzzle/PuzzleResult.tsx
+++ b/Backgammon.WebClient/src/components/puzzle/PuzzleResult.tsx
@@ -1,0 +1,123 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Check, X, Trophy, Flame, RotateCcw } from 'lucide-react'
+import { PuzzleResult as PuzzleResultType } from '@/types/puzzle.types'
+
+interface PuzzleResultProps {
+  result: PuzzleResultType | null
+  isOpen: boolean
+  onClose: () => void
+  onTryAgain: () => void
+}
+
+export function PuzzleResult({
+  result,
+  isOpen,
+  onClose,
+  onTryAgain,
+}: PuzzleResultProps) {
+  if (!result) return null
+
+  const isCorrect = result.isCorrect
+  const isPerfect = isCorrect && result.equityLoss === 0
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            {isCorrect ? (
+              <>
+                <Check className="h-6 w-6 text-green-500" />
+                <span className="text-green-500">
+                  {isPerfect ? 'Perfect!' : 'Correct!'}
+                </span>
+              </>
+            ) : (
+              <>
+                <X className="h-6 w-6 text-red-500" />
+                <span className="text-red-500">Not Quite</span>
+              </>
+            )}
+          </DialogTitle>
+          <DialogDescription>{result.feedback}</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-4">
+          {/* Equity info for correct answers */}
+          {isCorrect && result.equityLoss > 0 && (
+            <div className="bg-muted rounded-lg p-3">
+              <p className="text-sm text-muted-foreground">
+                Your move was within{' '}
+                <span className="font-mono font-bold">
+                  {result.equityLoss.toFixed(3)}
+                </span>{' '}
+                equity of optimal
+              </p>
+            </div>
+          )}
+
+          {/* Best move (shown when correct) */}
+          {isCorrect && result.bestMovesNotation && (
+            <div className="bg-green-500/10 border border-green-500/30 rounded-lg p-3">
+              <p className="text-sm font-medium text-green-400 mb-1">
+                Best Move
+              </p>
+              <p className="font-mono">{result.bestMovesNotation}</p>
+            </div>
+          )}
+
+          {/* Streak info */}
+          {isCorrect && (
+            <div className="flex items-center justify-center gap-6 pt-2">
+              <div className="flex items-center gap-2">
+                <Flame className="h-5 w-5 text-orange-500" />
+                <div>
+                  <p className="text-xs text-muted-foreground">Current Streak</p>
+                  <p className="font-bold text-lg">{result.currentStreak}</p>
+                </div>
+              </div>
+
+              {result.attemptCount === 1 && (
+                <Badge className="bg-yellow-500/20 text-yellow-400 border-yellow-500/30">
+                  <Trophy className="h-3 w-3 mr-1" />
+                  First Try!
+                </Badge>
+              )}
+            </div>
+          )}
+
+          {/* Attempt count for wrong answers */}
+          {!isCorrect && (
+            <div className="text-center text-sm text-muted-foreground">
+              Attempt #{result.attemptCount}
+            </div>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-2">
+          {isCorrect ? (
+            <Button onClick={onClose}>Done</Button>
+          ) : (
+            <>
+              <Button variant="outline" onClick={onClose}>
+                Close
+              </Button>
+              <Button onClick={onTryAgain}>
+                <RotateCcw className="h-4 w-4 mr-2" />
+                Try Again
+              </Button>
+            </>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/Backgammon.WebClient/src/components/puzzle/StreakDisplay.tsx
+++ b/Backgammon.WebClient/src/components/puzzle/StreakDisplay.tsx
@@ -1,0 +1,44 @@
+import { Trophy, Flame } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { PuzzleStreakInfo } from '@/types/puzzle.types'
+
+interface StreakDisplayProps {
+  streak: PuzzleStreakInfo | null
+}
+
+export function StreakDisplay({ streak }: StreakDisplayProps) {
+  if (!streak) {
+    return null
+  }
+
+  return (
+    <div className="flex items-center gap-4">
+      {/* Current streak */}
+      <div className="flex items-center gap-2">
+        <Flame className="h-5 w-5 text-orange-500" />
+        <div className="text-right">
+          <p className="text-xs text-muted-foreground">Streak</p>
+          <p className="font-bold">{streak.currentStreak}</p>
+        </div>
+      </div>
+
+      {/* Best streak */}
+      {streak.bestStreak > 0 && (
+        <div className="flex items-center gap-2">
+          <Trophy className="h-5 w-5 text-yellow-500" />
+          <div className="text-right">
+            <p className="text-xs text-muted-foreground">Best</p>
+            <p className="font-bold">{streak.bestStreak}</p>
+          </div>
+        </div>
+      )}
+
+      {/* Total solved badge */}
+      {streak.totalSolved > 0 && (
+        <Badge variant="secondary" className="ml-2">
+          {streak.totalSolved} solved
+        </Badge>
+      )}
+    </div>
+  )
+}

--- a/Backgammon.WebClient/src/hooks/useBoardDrag.ts
+++ b/Backgammon.WebClient/src/hooks/useBoardDrag.ts
@@ -1,0 +1,208 @@
+import { useRef, useCallback, useState, RefObject } from 'react'
+import {
+  BOARD_CONFIG,
+  BOARD_COLORS,
+  getPointAtPosition,
+  clientToSVGCoords,
+} from '@/lib/boardConstants'
+
+export interface DragState {
+  isDragging: boolean
+  sourcePoint: number | null
+  ghostPosition: { x: number; y: number } | null
+  ghostColor: 'white' | 'red' | null
+}
+
+export interface UseBoardDragOptions {
+  svgRef: RefObject<SVGSVGElement | null>
+  isBoardFlipped?: boolean
+  onMoveComplete: (from: number, to: number) => void
+  getValidDestinations: (from: number) => number[]
+}
+
+export interface UseBoardDragReturn {
+  dragState: DragState
+  validDestinations: number[]
+  startDrag: (
+    event: React.MouseEvent | React.TouchEvent,
+    pointNum: number,
+    color: 'white' | 'red'
+  ) => void
+  // For rendering ghost checker
+  ghostChecker: {
+    visible: boolean
+    x: number
+    y: number
+    color: 'white' | 'red'
+  } | null
+}
+
+const initialDragState: DragState = {
+  isDragging: false,
+  sourcePoint: null,
+  ghostPosition: null,
+  ghostColor: null,
+}
+
+export function useBoardDrag({
+  svgRef,
+  isBoardFlipped = false,
+  onMoveComplete,
+  getValidDestinations,
+}: UseBoardDragOptions): UseBoardDragReturn {
+  const [dragState, setDragState] = useState<DragState>(initialDragState)
+  const [validDestinations, setValidDestinations] = useState<number[]>([])
+
+  // Use ref for drag state to avoid stale closures in event handlers
+  const dragStateRef = useRef<DragState>(initialDragState)
+
+  const handleDragMove = useCallback(
+    (event: MouseEvent | TouchEvent) => {
+      if (!dragStateRef.current.isDragging || !svgRef.current) return
+
+      event.preventDefault()
+
+      let clientX: number, clientY: number
+      if (event.type === 'touchmove') {
+        const touch = (event as TouchEvent).touches[0]
+        clientX = touch.clientX
+        clientY = touch.clientY
+      } else {
+        clientX = (event as MouseEvent).clientX
+        clientY = (event as MouseEvent).clientY
+      }
+
+      const svgCoords = clientToSVGCoords(svgRef.current, clientX, clientY)
+      if (!svgCoords) return
+
+      // Update ghost position
+      dragStateRef.current = {
+        ...dragStateRef.current,
+        ghostPosition: svgCoords,
+      }
+
+      setDragState((prev) => ({
+        ...prev,
+        ghostPosition: svgCoords,
+      }))
+    },
+    [svgRef]
+  )
+
+  const handleDragEnd = useCallback(
+    (event: MouseEvent | TouchEvent) => {
+      if (!dragStateRef.current.isDragging || !svgRef.current) return
+
+      event.preventDefault()
+
+      let clientX: number, clientY: number
+      if (event.type === 'touchend') {
+        const touch = (event as TouchEvent).changedTouches[0]
+        clientX = touch.clientX
+        clientY = touch.clientY
+      } else {
+        clientX = (event as MouseEvent).clientX
+        clientY = (event as MouseEvent).clientY
+      }
+
+      // Determine drop target
+      const targetPoint = getPointAtPosition(
+        svgRef.current,
+        clientX,
+        clientY,
+        isBoardFlipped
+      )
+
+      const sourcePoint = dragStateRef.current.sourcePoint
+
+      // Remove global listeners
+      document.removeEventListener('mousemove', handleDragMove)
+      document.removeEventListener('mouseup', handleDragEnd)
+      document.removeEventListener('touchmove', handleDragMove)
+      document.removeEventListener('touchend', handleDragEnd)
+
+      // Reset drag state
+      dragStateRef.current = initialDragState
+      setDragState(initialDragState)
+      setValidDestinations([])
+
+      // Execute move if valid target
+      if (
+        targetPoint !== null &&
+        targetPoint !== sourcePoint &&
+        sourcePoint !== null
+      ) {
+        onMoveComplete(sourcePoint, targetPoint)
+      }
+    },
+    [svgRef, isBoardFlipped, onMoveComplete, handleDragMove]
+  )
+
+  const startDrag = useCallback(
+    (
+      event: React.MouseEvent | React.TouchEvent,
+      pointNum: number,
+      color: 'white' | 'red'
+    ) => {
+      if (!svgRef.current) return
+
+      event.preventDefault()
+
+      let clientX: number, clientY: number
+      if ('touches' in event) {
+        const touch = event.touches[0]
+        clientX = touch.clientX
+        clientY = touch.clientY
+      } else {
+        clientX = event.clientX
+        clientY = event.clientY
+      }
+
+      const svgCoords = clientToSVGCoords(svgRef.current, clientX, clientY)
+      if (!svgCoords) return
+
+      // Get valid destinations for highlighting
+      const destinations = getValidDestinations(pointNum)
+
+      // Update state
+      const newDragState: DragState = {
+        isDragging: true,
+        sourcePoint: pointNum,
+        ghostPosition: svgCoords,
+        ghostColor: color,
+      }
+
+      dragStateRef.current = newDragState
+      setDragState(newDragState)
+      setValidDestinations(destinations)
+
+      // Add global listeners
+      document.addEventListener('mousemove', handleDragMove)
+      document.addEventListener('mouseup', handleDragEnd)
+      document.addEventListener('touchmove', handleDragMove, { passive: false })
+      document.addEventListener('touchend', handleDragEnd)
+    },
+    [svgRef, getValidDestinations, handleDragMove, handleDragEnd]
+  )
+
+  // Compute ghost checker for rendering
+  const ghostChecker =
+    dragState.isDragging && dragState.ghostPosition && dragState.ghostColor
+      ? {
+          visible: true,
+          x: dragState.ghostPosition.x,
+          y: dragState.ghostPosition.y,
+          color: dragState.ghostColor,
+        }
+      : null
+
+  return {
+    dragState,
+    validDestinations,
+    startDrag,
+    ghostChecker,
+  }
+}
+
+// Re-export constants for convenience
+export { BOARD_CONFIG, BOARD_COLORS }

--- a/Backgammon.WebClient/src/lib/boardConstants.ts
+++ b/Backgammon.WebClient/src/lib/boardConstants.ts
@@ -1,0 +1,194 @@
+// Shared board configuration constants used by BoardSVG and PuzzleBoard
+
+export const BOARD_CONFIG = {
+  viewBox: { width: 1020, height: 500 },
+  sidebarWidth: 0,
+  margin: 10,
+  barWidth: 70,
+  pointWidth: 72,
+  pointHeight: 200,
+  padding: 25,
+  checkerRadius: 20,
+  checkerSpacing: 38,
+  bearoffWidth: 50,
+  get boardStartX() {
+    return this.sidebarWidth + this.margin
+  },
+  get barX() {
+    return this.boardStartX + 6 * this.pointWidth
+  },
+} as const
+
+// Color palette - matching shadcn default theme (neutral grays)
+// Note: Not using `as const` to allow reassignment of color values in components
+export const BOARD_COLORS: Record<string, string> = {
+  boardBackground: 'hsl(0 0% 14%)',
+  boardBorder: 'hsl(0 0% 22%)',
+  pointLight: 'hsl(0 0% 32%)',
+  pointDark: 'hsl(0 0% 20%)',
+  bar: 'hsl(0 0% 11%)',
+  bearoff: 'hsl(0 0% 11%)',
+  checkerWhite: 'hsl(0 0% 98%)',
+  checkerWhiteStroke: 'hsl(0 0% 72%)',
+  checkerRed: 'hsl(0 84.2% 60.2%)',
+  checkerRedStroke: 'hsl(0 72.2% 50.6%)',
+  highlightSource: 'hsla(47.9 95.8% 53.1% / 0.6)',
+  highlightSelected: 'hsla(142.1 76.2% 36.3% / 0.7)',
+  highlightDest: 'hsla(221.2 83.2% 53.3% / 0.6)',
+  highlightCapture: 'hsla(0 84.2% 60.2% / 0.6)',
+  highlightAnalysis: 'hsla(142.1 76.2% 36.3% / 0.5)',
+  textLight: 'hsla(0 0% 98% / 0.5)',
+  textDark: 'hsla(0 0% 9% / 0.7)',
+}
+
+// Pre-calculated point coordinates
+export interface PointCoords {
+  x: number
+  y: number
+  direction: number // 1 for top (points down), -1 for bottom (points up)
+}
+
+function calculatePointCoords(): Record<number, PointCoords> {
+  const coords: Record<number, PointCoords> = {}
+  const rightSideStart = BOARD_CONFIG.barX + BOARD_CONFIG.barWidth
+
+  // Top row - points 13-18 (left of bar)
+  for (let i = 0; i < 6; i++) {
+    const pointNum = 13 + i
+    coords[pointNum] = {
+      x: BOARD_CONFIG.boardStartX + i * BOARD_CONFIG.pointWidth,
+      y: BOARD_CONFIG.padding,
+      direction: 1,
+    }
+  }
+
+  // Top row - points 19-24 (right of bar)
+  for (let i = 0; i < 6; i++) {
+    const pointNum = 19 + i
+    coords[pointNum] = {
+      x: rightSideStart + i * BOARD_CONFIG.pointWidth,
+      y: BOARD_CONFIG.padding,
+      direction: 1,
+    }
+  }
+
+  // Bottom row - points 12-7 (left of bar)
+  for (let i = 0; i < 6; i++) {
+    const pointNum = 12 - i
+    coords[pointNum] = {
+      x: BOARD_CONFIG.boardStartX + i * BOARD_CONFIG.pointWidth,
+      y: BOARD_CONFIG.viewBox.height - BOARD_CONFIG.padding,
+      direction: -1,
+    }
+  }
+
+  // Bottom row - points 6-1 (right of bar)
+  for (let i = 0; i < 6; i++) {
+    const pointNum = 6 - i
+    coords[pointNum] = {
+      x: rightSideStart + i * BOARD_CONFIG.pointWidth,
+      y: BOARD_CONFIG.viewBox.height - BOARD_CONFIG.padding,
+      direction: -1,
+    }
+  }
+
+  return coords
+}
+
+export const POINT_COORDS = calculatePointCoords()
+
+/**
+ * Get the point number at the given client coordinates relative to an SVG element
+ */
+export function getPointAtPosition(
+  svgElement: SVGSVGElement,
+  clientX: number,
+  clientY: number,
+  isBoardFlipped: boolean = false
+): number | null {
+  const rect = svgElement.getBoundingClientRect()
+
+  // Calculate aspect ratios
+  const renderedAspect = rect.width / rect.height
+  const viewBoxAspect = BOARD_CONFIG.viewBox.width / BOARD_CONFIG.viewBox.height
+
+  // Adjust for non-uniform scaling (letterboxing/pillarboxing)
+  let effectiveWidth = rect.width
+  let effectiveHeight = rect.height
+  let offsetX = 0
+  let offsetY = 0
+
+  if (renderedAspect > viewBoxAspect) {
+    // Letterboxed (black bars on sides)
+    effectiveWidth = rect.height * viewBoxAspect
+    offsetX = (rect.width - effectiveWidth) / 2
+  } else if (renderedAspect < viewBoxAspect) {
+    // Pillarboxed (black bars on top/bottom)
+    effectiveHeight = rect.width / viewBoxAspect
+    offsetY = (rect.height - effectiveHeight) / 2
+  }
+
+  const scaleX = BOARD_CONFIG.viewBox.width / effectiveWidth
+  const scaleY = BOARD_CONFIG.viewBox.height / effectiveHeight
+
+  let x = (clientX - rect.left - offsetX) * scaleX
+  let y = (clientY - rect.top - offsetY) * scaleY
+
+  // Account for board flip
+  if (isBoardFlipped) {
+    x = BOARD_CONFIG.viewBox.width - x
+    y = BOARD_CONFIG.viewBox.height - y
+  }
+
+  // Check bar
+  if (x >= BOARD_CONFIG.barX && x <= BOARD_CONFIG.barX + BOARD_CONFIG.barWidth) {
+    return 0 // Bar
+  }
+
+  // Check bear-off (align with visual bear-off box position)
+  const bearoffStartX = BOARD_CONFIG.barX + BOARD_CONFIG.barWidth + 6 * BOARD_CONFIG.pointWidth
+  if (x >= bearoffStartX) {
+    return 25 // Bear-off
+  }
+
+  // Check points
+  const isTop = y < BOARD_CONFIG.viewBox.height / 2
+  const isLeftSide = x < BOARD_CONFIG.barX
+
+  let pointIndex: number
+  if (isLeftSide) {
+    pointIndex = Math.floor((x - BOARD_CONFIG.boardStartX) / BOARD_CONFIG.pointWidth)
+    if (pointIndex < 0 || pointIndex > 5) return null
+  } else {
+    const rightStart = BOARD_CONFIG.barX + BOARD_CONFIG.barWidth
+    pointIndex = Math.floor((x - rightStart) / BOARD_CONFIG.pointWidth)
+    if (pointIndex < 0 || pointIndex > 5) return null
+  }
+
+  // Map to point number
+  if (isTop) {
+    // Top row: 13-18 (left), 19-24 (right)
+    return isLeftSide ? 13 + pointIndex : 19 + pointIndex
+  } else {
+    // Bottom row: 12-7 (left), 6-1 (right)
+    return isLeftSide ? 12 - pointIndex : 6 - pointIndex
+  }
+}
+
+/**
+ * Convert client coordinates to SVG coordinates
+ */
+export function clientToSVGCoords(
+  svgElement: SVGSVGElement,
+  clientX: number,
+  clientY: number
+): { x: number; y: number } | null {
+  const svgPoint = svgElement.createSVGPoint()
+  svgPoint.x = clientX
+  svgPoint.y = clientY
+  const ctm = svgElement.getScreenCTM()
+  if (!ctm) return null
+
+  const svgCoords = svgPoint.matrixTransform(ctm.inverse())
+  return { x: svgCoords.x, y: svgCoords.y }
+}

--- a/Backgammon.WebClient/src/pages/DailyPuzzlePage.tsx
+++ b/Backgammon.WebClient/src/pages/DailyPuzzlePage.tsx
@@ -1,0 +1,394 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useSignalR } from '@/contexts/SignalRContext'
+import { HubMethods } from '@/types/signalr.types'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Brain, ArrowLeft, RotateCcw, Check, X, Flame, Calendar } from 'lucide-react'
+import { useToast } from '@/hooks/use-toast'
+import { usePuzzleStore, formatMovesForSubmission } from '@/stores/puzzleStore'
+import { DailyPuzzle, PuzzleResult as PuzzleResultType, PuzzleStreakInfo } from '@/types/puzzle.types'
+import { PuzzleBoard } from '@/components/puzzle/PuzzleBoard'
+import { PuzzleResult } from '@/components/puzzle/PuzzleResult'
+
+export const DailyPuzzlePage: React.FC = () => {
+  const navigate = useNavigate()
+  const { invoke, isConnected } = useSignalR()
+  const { toast } = useToast()
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const {
+    currentPuzzle,
+    isLoading,
+    error,
+    pendingMoves,
+    remainingDice,
+    result,
+    showResultModal,
+    streakInfo,
+    setPuzzle,
+    setLoading,
+    setError,
+    setResult,
+    setShowResultModal,
+    setStreakInfo,
+    clearMoves,
+    canSubmit,
+    undoLastMove,
+  } = usePuzzleStore()
+
+  // Load puzzle on mount
+  useEffect(() => {
+    const loadPuzzle = async () => {
+      if (!isConnected) return
+
+      setLoading(true)
+      setError(null)
+
+      try {
+        const puzzle = await invoke<DailyPuzzle>(HubMethods.GetDailyPuzzle)
+        setPuzzle(puzzle)
+
+        // Also load streak info
+        const streak = await invoke<PuzzleStreakInfo>(HubMethods.GetPuzzleStreak)
+        setStreakInfo(streak)
+      } catch (err) {
+        console.error('Failed to load puzzle:', err)
+        setError('Failed to load today\'s puzzle')
+        toast({
+          title: 'Error',
+          description: 'Failed to load today\'s puzzle',
+          variant: 'destructive',
+        })
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    loadPuzzle()
+  }, [isConnected, invoke, setPuzzle, setLoading, setError, setStreakInfo, toast])
+
+  const handleSubmit = async () => {
+    if (!canSubmit() || isSubmitting) return
+
+    setIsSubmitting(true)
+    try {
+      const moves = formatMovesForSubmission(pendingMoves)
+      const puzzleResult = await invoke<PuzzleResultType>(HubMethods.SubmitPuzzleAnswer, moves)
+      if (!puzzleResult) {
+        throw new Error('No result returned')
+      }
+
+      setResult(puzzleResult)
+      setShowResultModal(true)
+
+      // Update streak info
+      if (streakInfo) {
+        setStreakInfo({
+          ...streakInfo,
+          currentStreak: puzzleResult.currentStreak,
+        })
+      }
+
+      // If correct, update the puzzle to show it's solved
+      if (puzzleResult.isCorrect && currentPuzzle) {
+        setPuzzle({
+          ...currentPuzzle,
+          alreadySolved: true,
+          bestMoves: puzzleResult.bestMoves,
+          bestMovesNotation: puzzleResult.bestMovesNotation,
+        })
+      }
+    } catch (err) {
+      console.error('Failed to submit answer:', err)
+      toast({
+        title: 'Error',
+        description: 'Failed to submit your answer',
+        variant: 'destructive',
+      })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleReset = () => {
+    clearMoves()
+    setResult(null)
+  }
+
+  const handleBack = () => {
+    navigate('/')
+  }
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <Card className="w-96">
+          <CardContent className="p-8">
+            <div className="text-center space-y-4">
+              <Brain className="h-12 w-12 text-purple-500 animate-pulse mx-auto" />
+              <p className="text-muted-foreground">Loading today's puzzle...</p>
+              <div className="flex justify-center">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  if (error || !currentPuzzle) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <Card className="w-96">
+          <CardContent className="p-8">
+            <div className="text-center space-y-4">
+              <X className="h-12 w-12 text-destructive mx-auto" />
+              <p className="text-muted-foreground">{error || 'No puzzle available'}</p>
+              <Button onClick={handleBack}>Back to Home</Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="max-w-[1920px] mx-auto px-2 py-4">
+        {/* Header */}
+        <div className="mb-4 flex items-center gap-4">
+          <Button variant="ghost" size="icon" onClick={handleBack}>
+            <ArrowLeft className="h-5 w-5" />
+          </Button>
+          <Badge variant="secondary" className="text-lg py-2 px-4">
+            <Brain className="h-5 w-5 mr-2 text-purple-500" />
+            Daily Puzzle
+          </Badge>
+          {currentPuzzle.alreadySolved && (
+            <Badge variant="default" className="bg-green-600 py-2 px-4">
+              <Check className="h-4 w-4 mr-1" />
+              Solved
+            </Badge>
+          )}
+        </div>
+
+        <div className="grid grid-cols-1 xl:grid-cols-[280px_1fr_320px] gap-3">
+          {/* Left Sidebar - Puzzle Info */}
+          <div className="space-y-3">
+            {/* Date Card */}
+            <Card>
+              <CardContent className="p-4">
+                <div className="flex items-center gap-3">
+                  <Calendar className="h-10 w-10 text-muted-foreground" />
+                  <div>
+                    <p className="text-sm text-muted-foreground">Puzzle Date</p>
+                    <p className="font-semibold">
+                      {new Date(currentPuzzle.puzzleDate).toLocaleDateString('en-US', {
+                        weekday: 'short',
+                        month: 'short',
+                        day: 'numeric',
+                      })}
+                    </p>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Player to Move */}
+            <Card>
+              <CardContent className="p-4">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm text-muted-foreground">To Play</p>
+                    <p className="font-semibold text-lg">{currentPuzzle.currentPlayer}</p>
+                  </div>
+                  <div
+                    className={`w-8 h-8 rounded-full border-2 ${
+                      currentPuzzle.currentPlayer === 'White'
+                        ? 'bg-white border-gray-300'
+                        : 'bg-red-500 border-red-600'
+                    }`}
+                  />
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Streak Info */}
+            {streakInfo && (
+              <Card>
+                <CardContent className="p-4">
+                  <div className="flex items-center gap-3">
+                    <Flame className="h-10 w-10 text-orange-500" />
+                    <div>
+                      <p className="text-sm text-muted-foreground">Current Streak</p>
+                      <p className="font-bold text-2xl">{streakInfo.currentStreak}</p>
+                    </div>
+                  </div>
+                  {streakInfo.bestStreak > 0 && (
+                    <p className="text-xs text-muted-foreground mt-2">
+                      Best: {streakInfo.bestStreak} days
+                    </p>
+                  )}
+                </CardContent>
+              </Card>
+            )}
+
+            {/* Attempts info */}
+            {currentPuzzle.attemptsToday > 0 && (
+              <Card>
+                <CardContent className="p-4">
+                  <p className="text-sm text-center text-muted-foreground">
+                    Attempts today: {currentPuzzle.attemptsToday}
+                  </p>
+                </CardContent>
+              </Card>
+            )}
+          </div>
+
+          {/* Main Board Area */}
+          <div className="space-y-3">
+            <Card>
+              <CardContent className="p-2">
+                <PuzzleBoard puzzle={currentPuzzle} />
+              </CardContent>
+            </Card>
+          </div>
+
+          {/* Right Sidebar - Controls & Analysis */}
+          <div className="space-y-3">
+            {/* Dice display */}
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm">Dice Roll</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="flex items-center justify-center gap-4">
+                  {currentPuzzle.dice.map((die, i) => {
+                    // Count how many of this die value are remaining
+                    const usedCount = currentPuzzle.dice
+                      .slice(0, i)
+                      .filter((d) => d === die).length
+                    const remainingOfThisValue = remainingDice.filter((d) => d === die).length
+                    const isUsed = usedCount >= remainingOfThisValue
+
+                    return (
+                      <div
+                        key={i}
+                        className={`w-14 h-14 rounded-lg flex items-center justify-center text-2xl font-bold shadow-md ${
+                          !isUsed
+                            ? 'bg-white text-gray-900'
+                            : 'bg-muted text-muted-foreground opacity-50'
+                        }`}
+                      >
+                        {die}
+                      </div>
+                    )
+                  })}
+                </div>
+                <p className="text-xs text-center text-muted-foreground mt-3">
+                  {remainingDice.length === 0
+                    ? 'All dice used'
+                    : `${remainingDice.length} move${remainingDice.length !== 1 ? 's' : ''} remaining`}
+                </p>
+              </CardContent>
+            </Card>
+
+            {/* Your Moves */}
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm">Your Moves</CardTitle>
+              </CardHeader>
+              <CardContent>
+                {pendingMoves.length > 0 ? (
+                  <div className="space-y-2">
+                    {pendingMoves.map((move, i) => (
+                      <div
+                        key={i}
+                        className="flex items-center justify-between bg-muted/50 rounded px-3 py-2"
+                      >
+                        <span className="font-mono">
+                          {move.from === 0 ? 'bar' : move.from}/
+                          {move.to === 25 || move.to === 0 ? 'off' : move.to}
+                          {move.isHit && <span className="text-red-500">*</span>}
+                        </span>
+                        <Badge variant="outline">{move.dieValue}</Badge>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-sm text-muted-foreground text-center py-4">
+                    Make your moves on the board
+                  </p>
+                )}
+              </CardContent>
+            </Card>
+
+            {/* Best Move (shown after solving, hidden while practicing) */}
+            {currentPuzzle.alreadySolved &&
+              currentPuzzle.bestMovesNotation &&
+              remainingDice.length === 0 && (
+                <Card className="bg-green-500/10 border-green-500/30">
+                  <CardHeader className="pb-2">
+                    <CardTitle className="text-sm text-green-400">Best Move</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="font-mono text-lg">{currentPuzzle.bestMovesNotation}</p>
+                  </CardContent>
+                </Card>
+              )}
+
+            {/* Action buttons */}
+            <Card>
+              <CardContent className="p-4 space-y-3">
+                {!currentPuzzle.alreadySolved && (
+                  <Button
+                    className="w-full"
+                    size="lg"
+                    onClick={handleSubmit}
+                    disabled={!canSubmit() || isSubmitting}
+                  >
+                    {isSubmitting ? 'Submitting...' : 'Submit Answer'}
+                  </Button>
+                )}
+
+                <div className="flex gap-2">
+                  <Button
+                    variant="outline"
+                    className="flex-1"
+                    onClick={undoLastMove}
+                    disabled={pendingMoves.length === 0}
+                  >
+                    Undo
+                  </Button>
+                  <Button
+                    variant="outline"
+                    className="flex-1"
+                    onClick={handleReset}
+                    disabled={
+                      pendingMoves.length === 0 &&
+                      remainingDice.length === currentPuzzle.dice.length
+                    }
+                  >
+                    <RotateCcw className="h-4 w-4 mr-1" />
+                    Reset
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+
+        {/* Result modal */}
+        <PuzzleResult
+          result={result}
+          isOpen={showResultModal}
+          onClose={() => setShowResultModal(false)}
+          onTryAgain={handleReset}
+        />
+      </div>
+    </div>
+  )
+}

--- a/Backgammon.WebClient/src/stores/puzzleStore.ts
+++ b/Backgammon.WebClient/src/stores/puzzleStore.ts
@@ -1,0 +1,192 @@
+import { create } from 'zustand'
+import {
+  DailyPuzzle,
+  PuzzleResult,
+  PuzzleStreakInfo,
+  PendingPuzzleMove,
+  PuzzleMove,
+} from '@/types/puzzle.types'
+import { CheckerColor } from '@/types/game.types'
+
+interface PuzzleStore {
+  // Puzzle state
+  currentPuzzle: DailyPuzzle | null
+  isLoading: boolean
+  error: string | null
+
+  // User's current solution attempt
+  pendingMoves: PendingPuzzleMove[]
+  remainingDice: number[]
+
+  // Result state
+  result: PuzzleResult | null
+  showResultModal: boolean
+
+  // Streak info
+  streakInfo: PuzzleStreakInfo | null
+
+  // Board interaction
+  selectedPoint: number | null
+  validDestinations: number[]
+
+  // Actions
+  setPuzzle: (puzzle: DailyPuzzle | null) => void
+  setLoading: (loading: boolean) => void
+  setError: (error: string | null) => void
+
+  // Move management
+  addMove: (move: PendingPuzzleMove) => void
+  undoLastMove: () => void
+  clearMoves: () => void
+
+  // Result management
+  setResult: (result: PuzzleResult | null) => void
+  setShowResultModal: (show: boolean) => void
+
+  // Streak management
+  setStreakInfo: (info: PuzzleStreakInfo | null) => void
+
+  // Board interaction
+  setSelectedPoint: (point: number | null) => void
+  setValidDestinations: (destinations: number[]) => void
+
+  // Computed helpers
+  getPlayerColor: () => CheckerColor | null
+  getCurrentBoardState: () => DailyPuzzle['boardState'] | null
+  canSubmit: () => boolean
+
+  // Reset state
+  reset: () => void
+}
+
+const initialState = {
+  currentPuzzle: null,
+  isLoading: false,
+  error: null,
+  pendingMoves: [],
+  remainingDice: [],
+  result: null,
+  showResultModal: false,
+  streakInfo: null,
+  selectedPoint: null,
+  validDestinations: [],
+}
+
+export const usePuzzleStore = create<PuzzleStore>((set, get) => ({
+  ...initialState,
+
+  setPuzzle: (puzzle) => {
+    set({
+      currentPuzzle: puzzle,
+      pendingMoves: [],
+      remainingDice: puzzle ? [...puzzle.dice] : [],
+      result: null,
+      error: null,
+      selectedPoint: null,
+      validDestinations: [],
+    })
+  },
+
+  setLoading: (loading) => set({ isLoading: loading }),
+  setError: (error) => set({ error }),
+
+  addMove: (move) => {
+    const state = get()
+    const newPendingMoves = [...state.pendingMoves, move]
+
+    // Remove the used die from remaining dice
+    const newRemainingDice = [...state.remainingDice]
+    const dieIndex = newRemainingDice.indexOf(move.dieValue)
+    if (dieIndex !== -1) {
+      newRemainingDice.splice(dieIndex, 1)
+    }
+
+    set({
+      pendingMoves: newPendingMoves,
+      remainingDice: newRemainingDice,
+      selectedPoint: null,
+      validDestinations: [],
+    })
+  },
+
+  undoLastMove: () => {
+    const state = get()
+    if (state.pendingMoves.length === 0) return
+
+    const newPendingMoves = [...state.pendingMoves]
+    newPendingMoves.pop()
+
+    // Rebuild remainingDice from the original puzzle dice to preserve ordering
+    let newRemainingDice: number[] = []
+    const puzzleDice = state.currentPuzzle?.dice
+    if (puzzleDice && puzzleDice.length > 0) {
+      const availableDice = [...puzzleDice]
+
+      // Remove one occurrence of each used die from availableDice
+      for (const m of newPendingMoves) {
+        const idx = availableDice.indexOf(m.dieValue)
+        if (idx !== -1) {
+          availableDice.splice(idx, 1)
+        }
+      }
+
+      newRemainingDice = availableDice
+    }
+
+    set({
+      pendingMoves: newPendingMoves,
+      remainingDice: newRemainingDice,
+      selectedPoint: null,
+      validDestinations: [],
+    })
+  },
+
+  clearMoves: () => {
+    const state = get()
+    set({
+      pendingMoves: [],
+      remainingDice: state.currentPuzzle ? [...state.currentPuzzle.dice] : [],
+      selectedPoint: null,
+      validDestinations: [],
+    })
+  },
+
+  setResult: (result) => set({ result }),
+  setShowResultModal: (show) => set({ showResultModal: show }),
+  setStreakInfo: (info) => set({ streakInfo: info }),
+  setSelectedPoint: (point) => set({ selectedPoint: point }),
+  setValidDestinations: (destinations) => set({ validDestinations: destinations }),
+
+  getPlayerColor: () => {
+    const puzzle = get().currentPuzzle
+    if (!puzzle) return null
+    return puzzle.currentPlayer === 'White' ? CheckerColor.White : CheckerColor.Red
+  },
+
+  getCurrentBoardState: () => {
+    const state = get()
+    if (!state.currentPuzzle) return null
+    // Return the current puzzle board state as-is
+    return state.currentPuzzle.boardState
+  },
+
+  canSubmit: () => {
+    const state = get()
+    // Allow submit whenever there is at least one pending move; server will validate dice usage
+    return state.pendingMoves.length > 0
+  },
+
+  reset: () => set(initialState),
+}))
+
+/**
+ * Format moves as submission payload
+ */
+export function formatMovesForSubmission(moves: PendingPuzzleMove[]): PuzzleMove[] {
+  return moves.map((m) => ({
+    from: m.from,
+    to: m.to,
+    dieValue: m.dieValue,
+    isHit: m.isHit,
+  }))
+}

--- a/Backgammon.WebClient/src/types/puzzle.types.ts
+++ b/Backgammon.WebClient/src/types/puzzle.types.ts
@@ -1,0 +1,86 @@
+import { Point } from './game.types'
+
+/**
+ * A move in a puzzle solution
+ */
+export interface PuzzleMove {
+  from: number
+  to: number
+  dieValue: number
+  isHit: boolean
+}
+
+/**
+ * Board state for displaying a puzzle position
+ */
+export interface PuzzlePointState {
+  position: number
+  color: string | null
+  count: number
+}
+
+/**
+ * Daily puzzle as received from the server
+ */
+export interface DailyPuzzle {
+  puzzleId: string
+  puzzleDate: string
+  currentPlayer: string
+  dice: number[]
+  boardState: PuzzlePointState[]
+  whiteCheckersOnBar: number
+  redCheckersOnBar: number
+  whiteBornOff: number
+  redBornOff: number
+  alreadySolved: boolean
+  attemptsToday: number
+  bestMoves?: PuzzleMove[]
+  bestMovesNotation?: string
+}
+
+/**
+ * Result after submitting a puzzle answer
+ */
+export interface PuzzleResult {
+  isCorrect: boolean
+  equityLoss: number
+  feedback: string
+  bestMoves?: PuzzleMove[]
+  bestMovesNotation?: string
+  currentStreak: number
+  streakBroken: boolean
+  attemptCount: number
+}
+
+/**
+ * User's puzzle streak information
+ */
+export interface PuzzleStreakInfo {
+  userId?: string
+  currentStreak: number
+  bestStreak: number
+  lastSolvedDate?: string
+  totalSolved: number
+  totalAttempts: number
+}
+
+/**
+ * State of a move being made in puzzle mode
+ */
+export interface PendingPuzzleMove {
+  from: number
+  to: number
+  dieValue: number
+  isHit: boolean
+}
+
+/**
+ * Convert puzzle board state to game Point format
+ */
+export function puzzleBoardToPoints(puzzleBoard: PuzzlePointState[]): Point[] {
+  return puzzleBoard.map((p) => ({
+    position: p.position,
+    color: p.color === 'White' ? 0 : p.color === 'Red' ? 1 : null,
+    count: p.count,
+  }))
+}

--- a/Backgammon.WebClient/src/types/signalr.types.ts
+++ b/Backgammon.WebClient/src/types/signalr.types.ts
@@ -42,6 +42,12 @@ export const HubMethods = {
   SetCurrentPlayer: 'SetCurrentPlayer',
   AnalyzePosition: 'AnalyzePosition',
   FindBestMoves: 'FindBestMoves',
+
+  // Daily Puzzle
+  GetDailyPuzzle: 'GetDailyPuzzle',
+  SubmitPuzzleAnswer: 'SubmitPuzzleAnswer',
+  GetPuzzleStreak: 'GetPuzzleStreak',
+  GetHistoricalPuzzle: 'GetHistoricalPuzzle',
 } as const
 
 // SignalR event names (server → client)


### PR DESCRIPTION
## Summary

Implements the Daily Puzzle System (closes #91) where users solve auto-generated checker play puzzles:

- **One puzzle per day** generated at midnight UTC, shared globally
- **Auto-generated random positions** covering opening, midgame, bearing off, and contact phases
- **Configurable evaluator** (gnubg or heuristic) via appsettings.json
- **Streak tracking** with current streak, best streak, and total solved
- **Solution validation** accepts moves within equity tolerance of optimal

## Changes

### Backend
- `PuzzleSettings` configuration class for evaluator type, equity tolerance, generation time
- DynamoDB models: `DailyPuzzle`, `PuzzleAttempt`, `PuzzleStreakInfo`, DTOs
- `RandomPositionGenerator` for varied game phase positions
- `DailyPuzzleService` with solution validation and streak logic
- `DailyPuzzleGenerationService` BackgroundService for midnight UTC generation
- `DynamoDbPuzzleRepository` with single-table design
- SignalR methods: `GetDailyPuzzle`, `SubmitPuzzleAnswer`, `GetPuzzleStreak`, `GetHistoricalPuzzle`

### Frontend
- TypeScript types and Zustand store for puzzle state
- `DailyPuzzlePage` with interactive `PuzzleBoard` component
- `PuzzleResult` modal and `StreakDisplay` components
- Updated home page `DailyPuzzle` card with live data
- Route: `/puzzle`

## Test plan

- [ ] Verify puzzle generates on server startup if none exists for today
- [ ] Test puzzle board displays position correctly
- [ ] Verify moves can be made and submitted
- [ ] Check correct answer shows success feedback and best move
- [ ] Verify incorrect answer allows retry
- [ ] Test streak increments on correct answer
- [ ] Confirm home page card shows puzzle preview and streak

🤖 Generated with [Claude Code](https://claude.com/claude-code)