### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   test-coverage:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/GarrettBeatty/doublecube.gg/security/code-scanning/11](https://github.com/GarrettBeatty/doublecube.gg/security/code-scanning/11)

To fix this, we should add an explicit `permissions` block that limits the `GITHUB_TOKEN` to the least privileges needed. This can be done at the workflow root (applies to all jobs) or at the job level; since the warning is on the `test-coverage` job and there is only one job in the snippet, adding it at the job level is straightforward and precise.

The job needs:
- `contents: read` so `actions/checkout@v4` can read the repository.
- `pull-requests: write` so `marocchino/sticky-pull-request-comment@v2` can create/update PR comments.
No other write scopes are required by the shown steps. Therefore, in `.github/workflows/test-coverage.yml`, under `jobs:  test-coverage:`, just below `runs-on: ubuntu-latest`, add:

```yaml
    permissions:
      contents: read
      pull-requests: write
```

This change does not alter the workflow’s functionality; it only constrains the token permissions explicitly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
